### PR TITLE
Fixed The getter '_duration' was called on null error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This plugin is based on [Chewie](https://github.com/brianegan/chewie). Chewie is
 ✔️ Fixed common bugs  
 ✔️ Added advanced configuration options  
 ✔️ Refactored player controls  
-✔️ Playlist support  
+✔️ Playlist support  ``
 ✔️ Video in ListView support  
 ✔️ Subtitles support (HTML tags support)
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.7"
+    version: "0.0.10"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -422,7 +422,11 @@ class _BetterPlayerMaterialControlsState
   }
 
   void _onPlayPause() {
-    bool isFinished = _latestValue.position >= _latestValue.duration;
+    bool isFinished = false;
+
+    if (_latestValue?.position != null && _latestValue?.duration != null) {
+      isFinished = _latestValue.position >= _latestValue.duration;
+    }
 
     setState(() {
       if (_controller.value.isPlaying) {


### PR DESCRIPTION
Error:

```
The following NoSuchMethodError was thrown while handling a gesture:
The getter '_duration' was called on null.
Receiver: null
Tried calling: _duration

When the exception was thrown, this was the stack: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
#1      Duration.>= (dart:core/duration.dart:175:63)
#2      _BetterPlayerMaterialControlsState._onPlayPause (package:better_player/src/controls/better_player_material_controls.dart:425:45)
#3      _InkResponseState._handleTap (package:flutter/src/material/ink_well.dart:779:19)
#4      _InkResponseState.build.<anonymous closure> (package:flutter/src/material/ink_well.dart:862:36)
...
Handler: "onTap"
Recognizer: TapGestureRecognizer#d39cb
  debugOwner: GestureDetector
  state: ready
  won arena
  finalPosition: Offset(25.9, 287.6)
  finalLocalPosition: Offset(25.9, 30.9)
  button: 1
  sent tap down
```