### PR TITLE
Fix ios on dispose crash by removing duplicated removeObserver calls

### DIFF
--- a/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/ios/Classes/FLTVideoPlayerPlugin.m
@@ -500,19 +500,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)disposeSansEventChannel {
   [self clear];
   [_displayLink invalidate];
-  [[_player currentItem] removeObserver:self forKeyPath:@"status" context:statusContext];
-  [[_player currentItem] removeObserver:self
-                             forKeyPath:@"loadedTimeRanges"
-                                context:timeRangeContext];
-  [[_player currentItem] removeObserver:self
-                             forKeyPath:@"playbackLikelyToKeepUp"
-                                context:playbackLikelyToKeepUpContext];
-  [[_player currentItem] removeObserver:self
-                             forKeyPath:@"playbackBufferEmpty"
-                                context:playbackBufferEmptyContext];
-  [[_player currentItem] removeObserver:self
-                             forKeyPath:@"playbackBufferFull"
-                                context:playbackBufferFullContext];
   [_player replaceCurrentItemWithPlayerItem:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }


### PR DESCRIPTION
Related to this issue [https://github.com/jhomlala/betterplayer/issues/33](url)

`disposeSansEventChannel` Method already invokes  `clear` method

And as both disposeSansEventChannel and clear method are removing the observers, so these removeObservers are duplicated and called twice 
```
  [[_player currentItem] removeObserver:self forKeyPath:@"status" context:statusContext];
  [[_player currentItem] removeObserver:self
                             forKeyPath:@"loadedTimeRanges"
                                context:timeRangeContext];
  [[_player currentItem] removeObserver:self
                             forKeyPath:@"playbackLikelyToKeepUp"
                                context:playbackLikelyToKeepUpContext];
  [[_player currentItem] removeObserver:self
                             forKeyPath:@"playbackBufferEmpty"
                                context:playbackBufferEmptyContext];
  [[_player currentItem] removeObserver:self
                             forKeyPath:@"playbackBufferFull"
                                context:playbackBufferFullContext];
```

which leads to a crash on ios ondisposing the video player with the exception:
Terminating app due to uncaught exception 'NSRangeException', reason: 'Cannot remove an observer <FLTVideoPlayer 0x28351db00> for the key path "status" from <AVPlayerItem 0x28193fea0> because it is not registered as an observer.'

Commenting them from disposeSansEventChannel method is the solution 
