### PR TITLE
CONTROLS_VISIBLE and CONTROLS_HIDDEN work in iOS

### DIFF
--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -592,6 +592,7 @@ class _BetterPlayerCupertinoControlsState
   }
 
   void _onPlayerHide() {
+    _betterPlayerController.toggleControlsVisibility(!_hideStuff);
     widget.onControlsVisibilityChanged(!_hideStuff);
   }
 


### PR DESCRIPTION
It seems CONTROLS_VISIBLE and CONTROLS_HIDDEN were only made to work with lib/src/controls/better_player_material_controls.dart and not with lib/src/controls/better_player_cupertino_controls.dart. With this, these two events also work in iOS. 