### PR TITLE
Tap to hide as well as show controls in iOS.

### DIFF
--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -247,7 +247,17 @@ class _BetterPlayerCupertinoControlsState
     return Expanded(
       child: GestureDetector(
         onTap: _latestValue != null && _latestValue.isPlaying
-            ? _cancelAndRestartTimer
+            ? () {
+              if (_hideStuff == true) {
+                _cancelAndRestartTimer();
+              } else {
+                _hideTimer?.cancel();
+
+                setState(() {
+                  _hideStuff = true;
+                });
+              }
+            }
             : () {
                 _hideTimer?.cancel();
 


### PR DESCRIPTION
In iOS, tapping brings up the controls but does not hide them. With this, tapping hides controls also. 