### PR TITLE
FIX: Fix playlist stall after second video

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -275,6 +275,7 @@ class BetterPlayerController extends ChangeNotifier {
           Timer.periodic(Duration(milliseconds: 1000), (_timer) async {
         if (_nextVideoTime == 1) {
           _timer.cancel();
+          _nextVideoTimer = null;
         }
         _nextVideoTime -= 1;
         nextVideoTimeStreamController.add(_nextVideoTime);


### PR DESCRIPTION
Set _nextVideoTimer to null to allow start third video in playlist. Fix #48 #47 