### PR TITLE
fix placeholder not following video fit option

### DIFF
--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -64,6 +64,7 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
       BetterPlayerController betterPlayerController, BuildContext context) {
     return Container(
       child: Stack(
+        fit: StackFit.passthrough,
         children: <Widget>[
           betterPlayerController.placeholder ?? Container(),
           _BetterPlayerVideoFitWidget(


### PR DESCRIPTION
It seems as though allowing the parent Stack to be passthrough
forces the placeholder to fit within the bounds of the video's
fit options.

I tested this in my personal app as well as in the example repo
and can confirm that it does not affect other aspects, but this would
probably require more rigorous testing.

Fixes #62 