### PR TITLE
Removed listener to fix fullscreen exit behaviour when fullScreenByDe…

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -227,10 +227,6 @@ class BetterPlayerController extends ChangeNotifier {
       await videoPlayerController.seekTo(startAt);
     }
 
-    if (fullScreenByDefault) {
-      videoPlayerController.addListener(_fullScreenListener);
-    }
-
     ///General purpose listener
     videoPlayerController.addListener(_onVideoPlayerChanged);
   }


### PR DESCRIPTION
…fault is true
Hi,
with fullScreenByDefault is set true, when I exit fullscreen the listener will switch to fullscreen again once before listener is removed

The player behave correctly without adding this listener

Thank you
Best regards