### PR TITLE
Remove dependency to flutter_widgets.

### DIFF
--- a/lib/src/core/better_player.dart
+++ b/lib/src/core/better_player.dart
@@ -5,7 +5,7 @@ import 'package:better_player/src/core/better_player_with_controls.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_widgets/flutter_widgets.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 import 'package:wakelock/wakelock.dart';
 
 import 'better_player_controller_provider.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,11 +14,11 @@ dependencies:
     sdk: flutter
   open_iconic_flutter: ^0.3.0
   wakelock: ^0.2.0+1
-  flutter_widgets: ^0.1.12
   pedantic: ^1.8.0
   meta: ^1.2.3
   flutter_widget_from_html_core: ^0.5.0+5
   flutter_hls_parser: ^1.0.0
+  visibility_detector: ^0.1.5
 
 
 dev_dependencies:


### PR DESCRIPTION
[flutter_widgets](https://pub.dev/packages/flutter_widgets) is no longer maintained and we'd better use repackaged [visibility_detector](https://pub.dev/packages/visibility_detector).

For me, the current issue with flutter_widgets is that, it internally uses `MediaQuery.of` with `nullOk` parameter but recently, flutter master introduces nullable interfaces that finally removes `nullOk` from such API signatures... If we use `visibility_detector` only, it does not matter at all.
