### PR TITLE
feat: touch on screen will toggle to show/hide

### DIFF
--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -80,7 +80,13 @@ class _BetterPlayerCupertinoControlsState
         cancelAndRestartTimer();
       },
       child: GestureDetector(
-        onTap: cancelAndRestartTimer,
+        onTap: () {
+          _hideStuff
+              ? cancelAndRestartTimer()
+              : setState(() {
+                  _hideStuff = true;
+                });
+        },
         onDoubleTap: () {
           cancelAndRestartTimer();
           _onPlayPause();

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -69,7 +69,13 @@ class _BetterPlayerMaterialControlsState
         cancelAndRestartTimer();
       },
       child: GestureDetector(
-        onTap: cancelAndRestartTimer,
+        onTap: () {
+          _hideStuff
+              ? cancelAndRestartTimer()
+              : setState(() {
+                  _hideStuff = true;
+                });
+        },
         onDoubleTap: () {
           cancelAndRestartTimer();
           _onPlayPause();


### PR DESCRIPTION
It's currently not possible to hide control after it's visible.
The timer to auto-hide is 3 seconds, if I touch on screen this timer is reset and now I need to wait more 3 seconds to hide controls.
In cases where the video has subtitles its a great problem.