### PR TITLE
Fixed Android notification vibration issue, fixes #236

### DIFF
--- a/android/src/main/java/com/jhomlala/better_player/BetterPlayer.java
+++ b/android/src/main/java/com/jhomlala/better_player/BetterPlayer.java
@@ -205,7 +205,7 @@ final class BetterPlayer {
         String playerNotificationChannelName = notificationChannelName;
         if (notificationChannelName == null) {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                int importance = NotificationManager.IMPORTANCE_DEFAULT;
+                int importance = NotificationManager.IMPORTANCE_LOW;
                 NotificationChannel channel = new NotificationChannel(DEFAULT_NOTIFICATION_CHANNEL,
                         DEFAULT_NOTIFICATION_CHANNEL, importance);
                 channel.setDescription(DEFAULT_NOTIFICATION_CHANNEL);


### PR DESCRIPTION
This sets the notification channel importance to low as per https://github.com/google/ExoPlayer/issues/5890, causing notifications to no longer play sound or vibration when interacting with the player. This fixes #236 