### PR TITLE
Add fullScreenAspectRatio to copyWidth function

### DIFF
--- a/lib/src/configuration/better_player_configuration.dart
+++ b/lib/src/configuration/better_player_configuration.dart
@@ -184,7 +184,8 @@ class BetterPlayerConfiguration {
       overlay: overlay ?? this.overlay,
       errorBuilder: errorBuilder ?? this.errorBuilder,
       allowedScreenSleep: allowedScreenSleep ?? this.allowedScreenSleep,
-      fullScreenAspectRatio: fullScreenAspectRatio ?? this.fullScreenAspectRatio,
+      fullScreenAspectRatio:
+          fullScreenAspectRatio ?? this.fullScreenAspectRatio,
       deviceOrientationsOnFullScreen:
           deviceOrientationsOnFullScreen ?? this.deviceOrientationsOnFullScreen,
       systemOverlaysAfterFullScreen:

--- a/lib/src/configuration/better_player_configuration.dart
+++ b/lib/src/configuration/better_player_configuration.dart
@@ -184,6 +184,7 @@ class BetterPlayerConfiguration {
       overlay: overlay ?? this.overlay,
       errorBuilder: errorBuilder ?? this.errorBuilder,
       allowedScreenSleep: allowedScreenSleep ?? this.allowedScreenSleep,
+      fullScreenAspectRatio: fullScreenAspectRatio ?? this.fullScreenAspectRatio,
       deviceOrientationsOnFullScreen:
           deviceOrientationsOnFullScreen ?? this.deviceOrientationsOnFullScreen,
       systemOverlaysAfterFullScreen:


### PR DESCRIPTION
Looks like fullScreenAspectRatio is unused in this function IIUC the intention is to copy it.

This feature does not seem to work when I tested on device. This could possibly be the issue