### PR TITLE
Fix DRM widevine play in texture

### DIFF
--- a/android/src/main/java/com/jhomlala/better_player/BetterPlayer.java
+++ b/android/src/main/java/com/jhomlala/better_player/BetterPlayer.java
@@ -34,6 +34,9 @@ import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.HttpMediaDrmCallback;
+import com.google.android.exoplayer2.drm.DummyExoMediaDrm;
+import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
+import com.google.android.exoplayer2.drm.UnsupportedDrmException;
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.source.ClippingMediaSource;
@@ -73,6 +76,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import com.google.android.exoplayer2.PlaybackParameters;
 
@@ -139,8 +143,28 @@ final class BetterPlayer {
         if (licenseUrl != null && !licenseUrl.isEmpty()) {
             HttpMediaDrmCallback httpMediaDrmCallback =
                     new HttpMediaDrmCallback(licenseUrl, new DefaultHttpDataSourceFactory());
-            drmSessionManager = new DefaultDrmSessionManager.Builder()
-                    .setKeyRequestParameters(drmHeaders).build(httpMediaDrmCallback);
+            if (Util.SDK_INT < 18) {
+                Log.e(TAG, "Protected content not supported on API levels below 18");
+                drmSessionManager = null;
+            } else {
+                UUID drmSchemeUuid = Util.getDrmUuid("widevine");
+                drmSessionManager =
+                        new DefaultDrmSessionManager.Builder()
+                                .setUuidAndExoMediaDrmProvider(drmSchemeUuid,
+                                        uuid -> {
+                                            try {
+                                                FrameworkMediaDrm mediaDrm = FrameworkMediaDrm.newInstance(uuid);
+                                                // Force L3.
+                                                mediaDrm.setPropertyString("securityLevel", "L3");
+                                                return mediaDrm;
+                                            } catch (UnsupportedDrmException e) {
+                                                return new DummyExoMediaDrm();
+                                            }
+                                        })
+                                .setMultiSession(false)
+                                .setKeyRequestParameters(drmHeaders)
+                                .build(httpMediaDrmCallback);
+            }
         } else {
             drmSessionManager = null;
         }


### PR DESCRIPTION
**Before:**
drm widevine not working
<img width=200 src=https://user-images.githubusercontent.com/46503636/109140644-dc886900-776d-11eb-92af-4383e2f0a5b0.jpg>

**After:**
<img width=200 src=https://user-images.githubusercontent.com/46503636/109140649-dd20ff80-776d-11eb-8041-c72cb36dfe6c.jpg>


**Sources:**

- https://github.com/google/ExoPlayer/issues/7270#issuecomment-618064634
- https://github.com/darwinvtomy/drm_wv_fp_player/blob/943da324d3e284999337478953a706c422cffe9a/android/src/main/java/io/flutter/darwinvtomy/plugins/drm_wv_fp_player/DrmWvFpPlayerPlugin.java#L134