### PR TITLE
Making it so that we properly forget the Visbility Detector's Timer w…

### DIFF
--- a/lib/src/core/better_player.dart
+++ b/lib/src/core/better_player.dart
@@ -6,12 +6,10 @@ import 'package:better_player/better_player.dart';
 import 'package:better_player/src/configuration/better_player_controller_event.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/core/better_player_with_controls.dart';
-
 // Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-
 // Package imports:
 import 'package:visibility_detector/visibility_detector.dart';
 import 'package:wakelock/wakelock.dart';
@@ -123,6 +121,8 @@ class _BetterPlayerState extends State<BetterPlayer>
     WidgetsBinding.instance!.removeObserver(this);
     _controllerEventSubscription?.cancel();
     widget.controller.dispose();
+    VisibilityDetectorController.instance
+        .forget(Key("${widget.controller.hashCode}_key"));
     super.dispose();
   }
 


### PR DESCRIPTION
…hen disposing BetterPlayer

We noticed when running some tests around BetterPlayer that we we're failing due to a `VisibilityDetector`'s `Timer` not being disposed correctly. Upon further investigation, we found that [a `VisibilityDetector`'s timer can be disposed via `VisibilityDetectorController.instance.forget(key)`](https://github.com/google/flutter.widgets/issues/12#issuecomment-572603317). After adding this line to `BetterPlayer`'s dispose method, we were now disposing the `Timer` correctly, and our test passed.