### PR TITLE
Fix loading large video from network

### DIFF
--- a/ios/Classes/FLTBetterPlayerPlugin.m
+++ b/ios/Classes/FLTBetterPlayerPlugin.m
@@ -94,10 +94,6 @@ AVPictureInPictureController *_pipController;
     _player = [[AVPlayer alloc] init];
     _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
     
-    ///Fix for loading large videos
-    if (@available(iOS 10.0, *)) {
-        _player.automaticallyWaitsToMinimizeStalling = false;
-    }
     _displayLink = [CADisplayLink displayLinkWithTarget:frameUpdater
                                                selector:@selector(onDisplayLink:)];
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];


### PR DESCRIPTION
Document from Apple: https://developer.apple.com/documentation/avfoundation/avplayer/1643482-automaticallywaitstominimizestal

`automaticallyWaitsToMinimizeStalling` is true by default. So just need removing the redundant code