### PR TITLE
Fix end of video looping final second, and video stutter during AudioSession Deactivation

### DIFF
--- a/ios/Classes/FLTBetterPlayerPlugin.m
+++ b/ios/Classes/FLTBetterPlayerPlugin.m
@@ -197,6 +197,9 @@ AVPictureInPictureController *_pipController;
             [ self removeObservers];
             
         }
+        [_player pause];
+         _isPlaying = false;
+         _displayLink.paused = YES;
     }
 }
 

--- a/ios/Classes/FLTBetterPlayerPlugin.m
+++ b/ios/Classes/FLTBetterPlayerPlugin.m
@@ -971,8 +971,10 @@ NSMutableDictionary*  _artworkImageDict;
 }
 
 - (void) setRemoteCommandsNotificationNotActive{
-    // TODO: figure out how to handle closing AudioSession
-    //[[AVAudioSession sharedInstance] setActive:false error:nil];
+    if ([_players count] == 0) {
+        [[AVAudioSession sharedInstance] setActive:false error:nil];
+    }
+    
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
 }
 
@@ -1203,8 +1205,9 @@ NSMutableDictionary*  _artworkImageDict;
                     [player dispose];
                 }
             });
-            // TODO: Figure out what to do to disactivated AVAudioSession
-            // [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+            if ([_players count] == 0) {
+                [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+            }
             result(nil);
         } else if ([@"setLooping" isEqualToString:call.method]) {
             [player setIsLooping:[argsMap[@"looping"] boolValue]];

--- a/ios/Classes/FLTBetterPlayerPlugin.m
+++ b/ios/Classes/FLTBetterPlayerPlugin.m
@@ -971,7 +971,8 @@ NSMutableDictionary*  _artworkImageDict;
 }
 
 - (void) setRemoteCommandsNotificationNotActive{
-    [[AVAudioSession sharedInstance] setActive:false error:nil];
+    // TODO: figure out how to handle closing AudioSession
+    //[[AVAudioSession sharedInstance] setActive:false error:nil];
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
 }
 
@@ -1181,6 +1182,7 @@ NSMutableDictionary*  _artworkImageDict;
             }
             result(nil);
         } else if ([@"dispose" isEqualToString:call.method]) {
+            [player clear];
             [self disposeNotificationData:player];
             [self setRemoteCommandsNotificationNotActive];
             [_registry unregisterTexture:textureId];
@@ -1201,7 +1203,8 @@ NSMutableDictionary*  _artworkImageDict;
                     [player dispose];
                 }
             });
-            [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+            // TODO: Figure out what to do to disactivated AVAudioSession
+            // [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
             result(nil);
         } else if ([@"setLooping" isEqualToString:call.method]) {
             [player setIsLooping:[argsMap[@"looping"] boolValue]];


### PR DESCRIPTION
Alright, so this PR aims to fix 2 bugs that I discovered. I think I fixed them, but I'd like your feedback as much as possible to improve the fixes. I've provided an example repo to be able to reproduce the issue [here](https://github.com/NicholasNagy/example_code_better_player) (you will just need to modify the pubspec.yaml file to point the version/path of the better player you want to test with).

Alright, so bug 1: 

For some reason, the video player continues to play the last second or so over and over once it reaches the end of the video. I applied some fixes that essentially pause the video at the end (see commit 8d61a41). 

The reproduction steps is as follows:
1. Set up an HLS video
2. Let the video run to the end
3. Don't touch the video and watch the last second loop.

Here is a short video demonstrating this:

https://user-images.githubusercontent.com/40705372/117555203-1d80e180-b02b-11eb-85c0-19260d26c0c4.mp4

Here is a short video demonstrating my work after the proposed fix:


https://user-images.githubusercontent.com/40705372/117555983-26c17c80-b032-11eb-9218-e845a1b0a722.mp4


Alright, now for bug number 2:

This bug causes a stutter at the beginning of a video when I am scrolling. At the same time as the stutter, I get the same error as noted in issue #464 : 
```AVAudioSession_iOS.mm:1149 Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.```.

After further investigation, I realized that it has something to do with the video playing, while the shared instance of the audio session gets deactivated. 

This can happen in 2 ways:

1. The user is playing a video and the user navigates away, disposing the video as it's playing, causing the error and the potential app stutter. I added the following line to fix this: [Link](https://github.com/jhomlala/betterplayer/compare/master...NicholasNagy:master#diff-a770a1cb54c237e09560e4b9efeee77139112e12549495f4b11992e26006d528R1185). **Note**: the repo I provided does not provide a good environment to test this first way, so if you need it, let me know and I can provide an extra branch for you to checkout and see that the error still shows up.
2. The user has a video that is stopped/paused, and navigates to a new page with a video player that autoplays, which commences the disposal process of the previous videoplayer on the previous page. This also deactivates the audio session, while the new player is playing causing the the error shown above, and the stutter. My fix for this is to simply comment out the deactivation, but I don't think this is the optimal solution.

Here is a clip of the stutter I am talking about:

https://user-images.githubusercontent.com/40705372/117555878-047b2f00-b031-11eb-827f-8ebb9748f677.mp4

Note: Although not shown here, sometimes even the audio completely drops out, and you don't hear anything unless you press play/pause, or seek, etc. to get the audio to start playing again, because the session gets killed.

Here is a clip after my solution has been implemented (commit 38fe28c):

https://user-images.githubusercontent.com/40705372/117556079-0d6d0000-b033-11eb-8e37-d40481c47062.mp4

Although, the current as implemented solution does work, the audiosession never gets deactivated. Therefore the solution I propose would be to include a flag on initialization of the player to indicate whether the audiosession will be deactivated manually or not (if not continue with the same functionality, otherwise let the package user deactivate it when necessary), and we include a method in the controller to deactivate the audiosession manually on iOS. Any thoughts on this solution?

**Better Player version**

Version: ^0.0.66

**Smartphone (please complete the following information):**

Device: iPhone SE 2
OS: iOS 14.4.2