### PR TITLE
Skip parsing subtitle files with no cues

### DIFF
--- a/lib/src/subtitles/better_player_subtitles_factory.dart
+++ b/lib/src/subtitles/better_player_subtitles_factory.dart
@@ -91,6 +91,11 @@ class BetterPlayerSubtitlesFactory {
       components = value.split('\n\n');
     }
 
+    // Skip parsing files with no cues
+    if (components.length == 1) {
+      return [];
+    }
+
     final List<BetterPlayerSubtitle> subtitlesObj = [];
 
     final bool isWebVTT = components.contains("WEBVTT");


### PR DESCRIPTION
This cuts down on the number of exceptions when parsing out segmented caption files by skipping those which have no cues to parse.