### PR TITLE
Exposes all active eventListener

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -61,6 +61,9 @@ class BetterPlayerController {
   ///between flutter high level code and lower level native code.
   VideoPlayerController? videoPlayerController;
 
+  ///Expose all active eventListeners
+  List<Function(BetterPlayerEvent)?> get eventListeners => _eventListeners;
+
   /// Defines a event listener where video player events will be send.
   Function(BetterPlayerEvent)? get eventListener =>
       betterPlayerConfiguration.eventListener;


### PR DESCRIPTION
Feature:
Exposes all active eventListeners within the better_player_controller.dart file

Argument:
This functionality is useful when user are working with recycleController (controllers which will be reused after they have been disposed, or after the video has changed).
A good use case is if the user has a list of 100 videos within a pageviewer, creates 3 videoplayer, which then will be used to show all 100 videos (the pageviewer is always preloading the video before and after the current video).
This approach avoids within android the OOM Bug (because in android you can only create around 3 video player instances and after that the system won't let you create more)
Within iOS it is the same, except that you are able to create exactly 32 instances of the avplayer.

Conclusion:
By exposing the eventListeners, the developers are enabled to recycle the videos more efficiently