### PR TITLE
Fix iOS caching + add iOS feature: preCaching

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -6,13 +6,14 @@
 #import <Flutter/Flutter.h>
 #import <AVKit/AVKit.h>
 #import <AVFoundation/AVFoundation.h>
-#import <KTVHTTPCache/KTVHTTPCache.h>
 #import <GLKit/GLKit.h>
 #import "BetterPlayerTimeUtils.h"
 #import "BetterPlayerView.h"
 #import "BetterPlayerEzDrmAssetsLoaderDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+@class CacheManager;
 
 @interface BetterPlayer : NSObject <FlutterPlatformView, FlutterStreamHandler, AVPictureInPictureControllerDelegate>
 @property(readonly, nonatomic) AVPlayer* player;
@@ -44,8 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFrame:(CGRect)frame;
 - (void)setMixWithOthers:(bool)mixWithOthers;
 - (void)seekTo:(int)location;
-- (void)setDataSourceAsset:(NSString*)asset withKey:(NSString*)key withCertificateUrl:(NSString*)certificateUrl withLicenseUrl:(NSString*)licenseUrl overriddenDuration:(int) overriddenDuration;
-- (void)setDataSourceURL:(NSURL*)url withKey:(NSString*)key withCertificateUrl:(NSString*)certificateUrl withLicenseUrl:(NSString*)licenseUrl withHeaders:(NSDictionary*)headers withCache:(BOOL)useCache overriddenDuration:(int) overriddenDuration;
+- (void)setDataSourceAsset:(NSString*)asset withKey:(NSString*)key withCertificateUrl:(NSString*)certificateUrl withLicenseUrl:(NSString*)licenseUrl cacheKey:(NSString*)cacheKey cacheManager:(CacheManager*)cacheManager overriddenDuration:(int) overriddenDuration;
+- (void)setDataSourceURL:(NSURL*)url withKey:(NSString*)key withCertificateUrl:(NSString*)certificateUrl withLicenseUrl:(NSString*)licenseUrl withHeaders:(NSDictionary*)headers withCache:(BOOL)useCache cacheKey:(NSString*)cacheKey cacheManager:(CacheManager*)cacheManager overriddenDuration:(int) overriddenDuration;
 - (void)setVolume:(double)volume;
 - (void)setSpeed:(double)speed result:(FlutterResult)result;
 - (void) setAudioTrack:(NSString*) name index:(int) index;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "BetterPlayer.h"
+#import <better_player/better_player-Swift.h>
 
 static void* timeRangeContext = &timeRangeContext;
 static void* statusContext = &statusContext;

--- a/ios/Classes/BetterPlayerPlugin.h
+++ b/ios/Classes/BetterPlayerPlugin.h
@@ -6,7 +6,6 @@
 #import <Flutter/Flutter.h>
 #import <AVKit/AVKit.h>
 #import <AVFoundation/AVFoundation.h>
-#import <KTVHTTPCache/KTVHTTPCache.h>
 #import <GLKit/GLKit.h>
 #import "BetterPlayerTimeUtils.h"
 #import "BetterPlayer.h"

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -322,7 +322,7 @@ bool _remoteCommandsInitialized = false;
                 }
             }
 
-            if (headers == nil || headers == [ NSNull null ]){
+            if (headers == [ NSNull null ]){
                 headers = @{};
             }
             if (assetArg) {
@@ -424,7 +424,7 @@ bool _remoteCommandsInitialized = false;
             NSString* cacheKey = dataSource[@"cacheKey"];
             NSDictionary* headers = dataSource[@"headers"];
             NSNumber* maxCacheSize = dataSource[@"maxCacheSize"];
-            if (headers == nil || headers == [ NSNull null ]){
+            if (headers == [ NSNull null ]){
                 headers = @{};
             }
             [_cacheManager setMaxCacheSize:maxCacheSize];

--- a/ios/Classes/CacheManager.swift
+++ b/ios/Classes/CacheManager.swift
@@ -1,0 +1,122 @@
+//
+//  CacheManager.swift
+//  betterplayer
+//  Created by mrj on 11/06/2021.
+//
+import AVKit
+import Cache
+import Swime
+
+
+@objc public class CacheManager: NSObject {
+
+    // We store the last pre-cached CachingPlayerItem objects to be able to play even if the download
+    // has not finished.
+    var _preCachedURLs = Dictionary<String, CachingPlayerItem>()
+
+    var completionHandler: ((_ success:Bool) -> Void)? = nil
+
+    var diskConfig = DiskConfig(name: "BetterPlayerCache", expiry: .date(Date().addingTimeInterval(3600*24*30)), maxSize: 100*1024*1024)
+    let memoryConfig = MemoryConfig(expiry: .never, countLimit: 10, totalCostLimit: 10)
+
+    lazy var storage: Cache.Storage? = {
+        return try? Cache.Storage(diskConfig: diskConfig, memoryConfig: memoryConfig, transformer: TransformerFactory.forCodable(ofType: Data.self))
+    }()
+
+    @objc public func setMaxCacheSize(_ maxCacheSize: NSNumber?){
+        if let unsigned = maxCacheSize {
+            let _maxCacheSize = unsigned.uintValue
+            diskConfig = DiskConfig(name: "BetterPlayerCache", expiry: .date(Date().addingTimeInterval(3600*24*30)), maxSize: _maxCacheSize)
+        }        
+    }
+
+    // MARK: - Logic
+    @objc public func preCacheURL(_ url: URL, cacheKey: String?, withHeaders headers: Dictionary<NSObject,AnyObject>, completionHandler: ((_ success:Bool) -> Void)?) {
+        self.completionHandler = completionHandler
+        
+        
+        let _key: String = cacheKey ?? url.absoluteString
+        // Make sure the item is not already being downloaded
+        if self._preCachedURLs[_key] == nil {            
+            let item = self.getCachingPlayerItem(url, cacheKey: _key, headers: headers)
+            if !self._existsInStorage {
+                self._preCachedURLs[_key] = item
+                item.download()
+            } else {
+                self.completionHandler?(true)
+            }
+        } else {
+            self.completionHandler?(true)
+        }
+    }
+
+    // Flag whether the CachingPlayerItem was already cached.
+    var _existsInStorage: Bool = false
+
+    // Get a CachingPlayerItem either from the network if it's not cached or from the cache.
+    @objc public func getCachingPlayerItem(_ url: URL, cacheKey: String?, headers: Dictionary<NSObject,AnyObject>) -> CachingPlayerItem {
+        let playerItem: CachingPlayerItem
+        let _key: String = cacheKey ?? url.absoluteString
+        // Fetch ongoing pre-cached url if it exists
+        if self._preCachedURLs[_key] != nil {
+            playerItem = self._preCachedURLs[_key]!
+            self._preCachedURLs.removeValue(forKey: _key)
+        } else {
+            // Trying to retrieve a track from cache syncronously
+            let data = try? storage?.object(forKey: _key)
+            if data != nil {
+                // The file is cached.
+                // We need to retrieve mimeType from Data
+                let mimeType = Swime.mimeType(data: data!)
+                self._existsInStorage = true
+                if let _mimeType = mimeType {
+                    playerItem = CachingPlayerItem(data: data!, mimeType: _mimeType.mime, fileExtension: _mimeType.ext)                    
+                    NSLog("File found in cache")
+                } else {
+                    NSLog("Error: could not retrieve mimeType from Data")
+                    playerItem = CachingPlayerItem(data: data!, mimeType: "video/mpeg", fileExtension: "mp4")
+                }
+            } else {
+                // The file is not cached.
+                playerItem = CachingPlayerItem(url: url, cacheKey: _key, headers: headers)
+                self._existsInStorage = false
+                NSLog("File not found in cache")
+            }
+        }
+
+        playerItem.delegate = self
+        return playerItem
+    }
+    
+    // Remove all objects
+    @objc public func clearCache(){
+        try? storage?.removeAll()
+        self._preCachedURLs = Dictionary<String,CachingPlayerItem>()
+    }
+
+
+}
+
+
+// MARK: - CachingPlayerItemDelegate
+extension CacheManager: CachingPlayerItemDelegate {
+    func playerItem(_ playerItem: CachingPlayerItem, didFinishDownloadingData data: Data) {
+        // A track is downloaded. Saving it to the cache asynchronously.
+        NSLog("File downloaded successfully, saving to cache...")
+        storage?.async.setObject(data, forKey: playerItem.cacheKey ?? playerItem.url.absoluteString, completion: { _ in })
+        self.completionHandler?(true)
+    }
+
+/*     func playerItem(_ playerItem: CachingPlayerItem, didDownloadBytesSoFar bytesDownloaded: Int, outOf bytesExpected: Int){
+        /// Is called every time a new portion of data is received.
+        let percentage = Double(bytesDownloaded)/Double(bytesExpected)*100.0
+        let str = String(format: "%.1f%%", percentage)
+        NSLog("Downloading... %@", str)
+    } */
+
+    func playerItem(_ playerItem: CachingPlayerItem, downloadingFailedWith error: Error){
+        /// Is called on downloading error.
+        NSLog("Error when downloading the file %@", error as NSError);
+        self.completionHandler?(false)
+    }
+}

--- a/ios/Classes/CachingPlayerItem.swift
+++ b/ios/Classes/CachingPlayerItem.swift
@@ -1,0 +1,286 @@
+import Foundation
+import AVFoundation
+
+fileprivate extension URL {
+    
+    func withScheme(_ scheme: String) -> URL? {
+        var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        components?.scheme = scheme
+        return components?.url
+    }
+    
+}
+
+@objc protocol CachingPlayerItemDelegate {
+    
+    /// Is called when the media file is fully downloaded.
+    @objc optional func playerItem(_ playerItem: CachingPlayerItem, didFinishDownloadingData data: Data)
+    
+    /// Is called every time a new portion of data is received.
+    @objc optional func playerItem(_ playerItem: CachingPlayerItem, didDownloadBytesSoFar bytesDownloaded: Int, outOf bytesExpected: Int)
+    
+    /// Is called after initial prebuffering is finished, means
+    /// we are ready to play.
+    @objc optional func playerItemReadyToPlay(_ playerItem: CachingPlayerItem)
+    
+    /// Is called when the data being downloaded did not arrive in time to
+    /// continue playback.
+    @objc optional func playerItemPlaybackStalled(_ playerItem: CachingPlayerItem)
+    
+    /// Is called on downloading error.
+    @objc optional func playerItem(_ playerItem: CachingPlayerItem, downloadingFailedWith error: Error)
+    
+}
+
+open class CachingPlayerItem: AVPlayerItem {
+    
+    class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSessionDelegate, URLSessionDataDelegate, URLSessionTaskDelegate {
+        
+        var playingFromData = false
+        var mimeType: String? // is required when playing from Data
+        var session: URLSession?
+        var headers: Dictionary<NSObject,AnyObject>?
+        var mediaData: Data?
+        var response: URLResponse?
+        var pendingRequests = Set<AVAssetResourceLoadingRequest>()
+        weak var owner: CachingPlayerItem?
+        
+        func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
+            
+            if playingFromData {
+                
+                // Nothing to load.
+                
+            } else if session == nil {
+                
+                // If we're playing from a url, we need to download the file.
+                // We start loading the file on first request only.
+                guard let initialUrl = owner?.url else {
+                    fatalError("internal inconsistency")
+                }
+
+                startDataRequest(with: initialUrl)
+            }
+            
+            pendingRequests.insert(loadingRequest)
+            processPendingRequests()
+            return true
+            
+        }
+        
+        func startDataRequest(with url: URL) {
+            let configuration = URLSessionConfiguration.default
+            configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            if let unwrappedDict = self.headers {
+                for (_key, _value) in unwrappedDict.enumerated() {                    
+                    request.setValue((_value as! String), forHTTPHeaderField: (_key as! String))
+                }
+            }        
+            session?.dataTask(with: request).resume()
+        }
+        
+        func resourceLoader(_ resourceLoader: AVAssetResourceLoader, didCancel loadingRequest: AVAssetResourceLoadingRequest) {
+            pendingRequests.remove(loadingRequest)
+        }
+        
+        // MARK: URLSession delegate
+        
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            mediaData?.append(data)
+            processPendingRequests()
+            owner?.delegate?.playerItem?(owner!, didDownloadBytesSoFar: mediaData!.count, outOf: Int(dataTask.countOfBytesExpectedToReceive))
+        }
+        
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+            completionHandler(Foundation.URLSession.ResponseDisposition.allow)
+            mediaData = Data()
+            self.response = response
+            processPendingRequests()
+        }
+        
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            if let errorUnwrapped = error {
+                owner?.delegate?.playerItem?(owner!, downloadingFailedWith: errorUnwrapped)
+                return
+            }
+            processPendingRequests()
+            owner?.delegate?.playerItem?(owner!, didFinishDownloadingData: mediaData!)
+        }
+        
+        // MARK: -
+        
+        func processPendingRequests() {
+            
+            // get all fullfilled requests
+            let requestsFulfilled = Set<AVAssetResourceLoadingRequest>(pendingRequests.compactMap {
+                self.fillInContentInformationRequest($0.contentInformationRequest)
+                if self.haveEnoughDataToFulfillRequest($0.dataRequest!) {
+                    $0.finishLoading()
+                    return $0
+                }
+                return nil
+            })
+        
+            // remove fulfilled requests from pending requests
+            _ = requestsFulfilled.map { self.pendingRequests.remove($0) }
+
+        }
+        
+        func fillInContentInformationRequest(_ contentInformationRequest: AVAssetResourceLoadingContentInformationRequest?) {
+            
+            // if we play from Data we make no url requests, therefore we have no responses, so we need to fill in contentInformationRequest manually
+            if playingFromData {
+                contentInformationRequest?.contentType = self.mimeType
+                contentInformationRequest?.contentLength = Int64(mediaData!.count)
+                contentInformationRequest?.isByteRangeAccessSupported = true
+                return
+            }
+            
+            guard let responseUnwrapped = response else {
+                // have no response from the server yet
+                return
+            }
+            
+            contentInformationRequest?.contentType = responseUnwrapped.mimeType
+            contentInformationRequest?.contentLength = responseUnwrapped.expectedContentLength
+            contentInformationRequest?.isByteRangeAccessSupported = true
+            
+        }
+        
+        func haveEnoughDataToFulfillRequest(_ dataRequest: AVAssetResourceLoadingDataRequest) -> Bool {
+            
+            let requestedOffset = Int(dataRequest.requestedOffset)
+            let requestedLength = dataRequest.requestedLength
+            let currentOffset = Int(dataRequest.currentOffset)
+            
+            guard let songDataUnwrapped = mediaData,
+                songDataUnwrapped.count > currentOffset else {
+                // Don't have any data at all for this request.
+                return false
+            }
+            
+            let bytesToRespond = min(songDataUnwrapped.count - currentOffset, requestedLength)
+            let dataToRespond = songDataUnwrapped.subdata(in: Range(uncheckedBounds: (currentOffset, currentOffset + bytesToRespond)))
+            dataRequest.respond(with: dataToRespond)
+            
+            return songDataUnwrapped.count >= requestedLength + requestedOffset
+            
+        }
+        
+        deinit {
+            session?.invalidateAndCancel()
+        }
+        
+    }
+    
+    fileprivate let resourceLoaderDelegate = ResourceLoaderDelegate()
+    let url: URL
+    var cacheKey: String? = nil
+    fileprivate let initialScheme: String?
+    fileprivate var customFileExtension: String?
+    
+    weak var delegate: CachingPlayerItemDelegate?
+    
+    open func download() {
+        if resourceLoaderDelegate.session == nil {
+            resourceLoaderDelegate.startDataRequest(with: url)
+        }
+    }
+    
+    private let cachingPlayerItemScheme = "cachingPlayerItemScheme"
+    
+    /// Is used for playing remote files.
+    convenience init(url: URL, cacheKey: String?, headers: Dictionary<NSObject,AnyObject>) {
+        self.init(url: url, customFileExtension: nil, cacheKey: cacheKey, headers: headers)
+    }
+    
+    /// Override/append custom file extension to URL path.
+    /// This is required for the player to work correctly with the intended file type.
+    init(url: URL, customFileExtension: String?, cacheKey: String?, headers: Dictionary<NSObject,AnyObject>) {
+    
+        self.cacheKey = cacheKey
+        
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let scheme = components.scheme,
+            var urlWithCustomScheme = url.withScheme(cachingPlayerItemScheme) else {
+            fatalError("Urls without a scheme are not supported")
+        }
+        
+        self.url = url
+        self.initialScheme = scheme
+        
+        if let ext = customFileExtension {
+            urlWithCustomScheme.deletePathExtension()
+            urlWithCustomScheme.appendPathExtension(ext)
+            self.customFileExtension = ext
+        }
+        
+        resourceLoaderDelegate.headers = headers
+        
+        
+        
+        let asset = AVURLAsset(url: urlWithCustomScheme)
+        asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: DispatchQueue.main)
+        super.init(asset: asset, automaticallyLoadedAssetKeys: nil)
+        
+        resourceLoaderDelegate.owner = self
+        
+        addObserver(self, forKeyPath: "status", options: NSKeyValueObservingOptions.new, context: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(playbackStalledHandler), name:NSNotification.Name.AVPlayerItemPlaybackStalled, object: self)
+        
+    }
+    
+    /// Is used for playing from Data.
+    init(data: Data, mimeType: String, fileExtension: String) {
+        
+        guard let fakeUrl = URL(string: cachingPlayerItemScheme + "://whatever/file.\(fileExtension)") else {
+            fatalError("internal inconsistency")
+        }
+        
+        self.url = fakeUrl
+        self.initialScheme = nil
+        
+        resourceLoaderDelegate.mediaData = data
+        resourceLoaderDelegate.playingFromData = true
+        resourceLoaderDelegate.mimeType = mimeType
+        
+        let asset = AVURLAsset(url: fakeUrl)
+        asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: DispatchQueue.main)
+        super.init(asset: asset, automaticallyLoadedAssetKeys: nil)
+        resourceLoaderDelegate.owner = self
+        
+        addObserver(self, forKeyPath: "status", options: NSKeyValueObservingOptions.new, context: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(playbackStalledHandler), name:NSNotification.Name.AVPlayerItemPlaybackStalled, object: self)
+        
+    }
+    
+    // MARK: KVO
+    
+    override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        delegate?.playerItemReadyToPlay?(self)
+    }
+    
+    // MARK: Notification hanlers
+    
+    @objc func playbackStalledHandler() {
+        delegate?.playerItemPlaybackStalled?(self)
+    }
+
+    // MARK: -
+    
+    override init(asset: AVAsset, automaticallyLoadedAssetKeys: [String]?) {
+        fatalError("not implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        removeObserver(self, forKeyPath: "status")
+        resourceLoaderDelegate.session?.invalidateAndCancel()
+    }
+    
+}

--- a/ios/Classes/CachingPlayerItem.swift
+++ b/ios/Classes/CachingPlayerItem.swift
@@ -1,3 +1,8 @@
+//
+//  Code from https://github.com/neekeetab/CachingPlayerItem.
+//  Edited by mrj to allow using cacheKey and headers.
+//
+
 import Foundation
 import AVFoundation
 
@@ -46,26 +51,19 @@ open class CachingPlayerItem: AVPlayerItem {
         weak var owner: CachingPlayerItem?
         
         func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
-            
             if playingFromData {
-                
                 // Nothing to load.
-                
             } else if session == nil {
-                
                 // If we're playing from a url, we need to download the file.
                 // We start loading the file on first request only.
                 guard let initialUrl = owner?.url else {
                     fatalError("internal inconsistency")
                 }
-
                 startDataRequest(with: initialUrl)
             }
-            
             pendingRequests.insert(loadingRequest)
             processPendingRequests()
             return true
-            
         }
         
         func startDataRequest(with url: URL) {
@@ -200,27 +198,22 @@ open class CachingPlayerItem: AVPlayerItem {
     /// Override/append custom file extension to URL path.
     /// This is required for the player to work correctly with the intended file type.
     init(url: URL, customFileExtension: String?, cacheKey: String?, headers: Dictionary<NSObject,AnyObject>) {
-    
         self.cacheKey = cacheKey
+        self.url = url
+        self.resourceLoaderDelegate.headers = headers
         
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             let scheme = components.scheme,
             var urlWithCustomScheme = url.withScheme(cachingPlayerItemScheme) else {
             fatalError("Urls without a scheme are not supported")
         }
-        
-        self.url = url
         self.initialScheme = scheme
-        
+
         if let ext = customFileExtension {
             urlWithCustomScheme.deletePathExtension()
             urlWithCustomScheme.appendPathExtension(ext)
             self.customFileExtension = ext
         }
-        
-        resourceLoaderDelegate.headers = headers
-        
-        
         
         let asset = AVURLAsset(url: urlWithCustomScheme)
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: DispatchQueue.main)
@@ -231,7 +224,6 @@ open class CachingPlayerItem: AVPlayerItem {
         addObserver(self, forKeyPath: "status", options: NSKeyValueObservingOptions.new, context: nil)
         
         NotificationCenter.default.addObserver(self, selector: #selector(playbackStalledHandler), name:NSNotification.Name.AVPlayerItemPlaybackStalled, object: self)
-        
     }
     
     /// Is used for playing from Data.
@@ -256,7 +248,6 @@ open class CachingPlayerItem: AVPlayerItem {
         addObserver(self, forKeyPath: "status", options: NSKeyValueObservingOptions.new, context: nil)
         
         NotificationCenter.default.addObserver(self, selector: #selector(playbackStalledHandler), name:NSNotification.Name.AVPlayerItemPlaybackStalled, object: self)
-        
     }
     
     // MARK: KVO

--- a/ios/better_player.podspec
+++ b/ios/better_player.podspec
@@ -15,8 +15,8 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  # KTVHTTPCache
-  s.dependency 'KTVHTTPCache', '~> 2.0.0'
+  s.dependency 'Cache'
+  s.dependency 'Swime'
   
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1191,15 +1191,14 @@ class BetterPlayerController {
     return headers;
   }
 
-  ///PreCache a video. Currently supports Android only. The future succeed when
+  ///PreCache a video. On Android, the future succeeds when
   ///the requested size, specified in
   ///[BetterPlayerCacheConfiguration.preCacheSize], is downloaded or when the
   ///complete file is downloaded if the file is smaller than the requested size.
+  ///On iOS, the whole file will be downloaded, since [maxCacheFileSize] is
+  ///currently not supported on iOS. On iOS, the video format must be in this
+  ///list: https://github.com/sendyhalim/Swime/blob/master/Sources/MimeType.swift
   Future<void> preCache(BetterPlayerDataSource betterPlayerDataSource) async {
-    if (!Platform.isAndroid) {
-      return Future.error("preCache is currently only supported on Android.");
-    }
-
     final cacheConfig = betterPlayerDataSource.cacheConfiguration ??
         const BetterPlayerCacheConfiguration(useCache: true);
 


### PR DESCRIPTION
On iOS, caching currently does not work as expected, because the cacheKey is ignored. This PR builds a new caching system on iOS which fixes this and also allows pre-caching, which I had previously only added on Android. With this PR, betterplayer will be the only library that fully supports caching and pre-caching videos on both platforms.
Limitations: preCaching on iOS currently does not support pre-caching only a chunk of the file. The whole file will be downloaded, therefore devs should be careful when using the feature with big files.
HLS: the current system is to load everything into memory and save the file to disk once downloaded, so if you plan to read a stream for 2 hours, probably not. But anyway, who uses cache with hls? Since I don't, I recon someone tests it with HLS, I can't tell what the result will be. It should at least play since the base it still an AVPlayerItem.

This is the response to the #548 lost in translation...