### PR TITLE
Fix for Issue #809

### DIFF
--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -382,12 +382,12 @@ class _BetterPlayerMaterialControlsState
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 if (_controlsConfiguration.enableSkips)
-                  _buildSkipButton()
+                  Expanded(child: _buildSkipButton())
                 else
                   const SizedBox(),
-                _buildReplayButton(_controller!),
+                Expanded(child: _buildReplayButton(_controller!)),
                 if (_controlsConfiguration.enableSkips)
-                  _buildForwardButton()
+                  Expanded(child: _buildForwardButton())
                 else
                   const SizedBox(),
               ],


### PR DESCRIPTION
Fix bug where a render error can occur on Android if the width of the player less than 240 pixels.

This bug was reported as Issue #809 .

Briefly, the fix is to wrap the 3 controls in the middle row in Expanded widgets to allow the layout to reduce their size to fit the width of the player, if needed.

