### PR TITLE
Fix dash frameRate exception

### DIFF
--- a/lib/src/dash/better_player_dash_utils.dart
+++ b/lib/src/dash/better_player_dash_utils.dart
@@ -50,8 +50,14 @@ class BetterPlayerDashUtils {
           int.parse(representation.getAttribute('height') ?? '0');
       final int bitrate =
           int.parse(representation.getAttribute('bandwidth') ?? '0');
-      final int frameRate =
-          int.parse(representation.getAttribute('frameRate') ?? '0');
+      int frameRate = 0;
+      final String? framRateStr = representation.getAttribute('frameRate');
+      final arr = framRateStr?.split('/');
+      if (arr?[1].isEmpty == false ) {
+        frameRate = (int.parse(arr?[0] ?? '0') / int.parse(arr?[1] ?? '1')).round();
+      } else {
+        frameRate = int.parse(framRateStr ?? '0');
+      }
       final String? codecs = representation.getAttribute('codecs');
       final String? mimeType = MimeTypes.getMediaMimeType(codecs ?? '');
       tracks.add(BetterPlayerAsmsTrack(


### PR DESCRIPTION
by AWS VOD DASH manifest examples documents the frame rate is not always int

frameRate="30000/1001"

https://docs.aws.amazon.com/mediatailor/latest/ug/dash-manifest-vod.html