### PR TITLE
Fix tracks when there's no mime in dash

### DIFF
--- a/lib/src/dash/better_player_dash_utils.dart
+++ b/lib/src/dash/better_player_dash_utils.dart
@@ -18,15 +18,26 @@ class BetterPlayerDashUtils {
       final document = XmlDocument.parse(data);
       final adaptationSets = document.findAllElements('AdaptationSet');
       adaptationSets.forEach((node) {
+        var type = node.getAttribute('contentType');
         final mimeType = node.getAttribute('mimeType');
 
-        if (mimeType != null) {
+        if (mimeType != null && type == null) {
           if (MimeTypes.isVideo(mimeType)) {
-            tracks = tracks + parseVideo(node);
+            type = "video";
           } else if (MimeTypes.isAudio(mimeType)) {
+            type = "audio";
+          } else if (MimeTypes.isText(mimeType)) {
+            type = "text";
+          }
+        }
+
+        if (type != null) {
+          if (type == "video") {
+            tracks = tracks + parseVideo(node);
+          } else if (type == "audio") {
             audios.add(parseAudio(node, audiosCount));
             audiosCount += 1;
-          } else if (MimeTypes.isText(mimeType)) {
+          } else if (type == "text") {
             subtitles.add(parseSubtitle(masterPlaylistUrl, node));
           }
         }


### PR DESCRIPTION
Not all dash files have mime attribute in AdaptationSet. In this case the player cannot parse track information. The pull request taking into account contentType attribute.