### PR TITLE
Fix SafeArea cropping background of ModalBottomSheet

### DIFF
--- a/lib/src/controls/better_player_controls_state.dart
+++ b/lib/src/controls/better_player_controls_state.dart
@@ -458,19 +458,19 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
           betterPlayerController?.betterPlayerConfiguration.useRootNavigator ??
               false,
       builder: (context) {
-        return SafeArea(
-          top: false,
-          child: SingleChildScrollView(
-            physics: const BouncingScrollPhysics(),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-              decoration: BoxDecoration(
-                color: betterPlayerControlsConfiguration.overflowModalColor,
-                /*shape: RoundedRectangleBorder(side: Bor,borderRadius: 24,)*/
-                borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(24.0),
-                    topRight: Radius.circular(24.0)),
-              ),
+        return SingleChildScrollView(
+          physics: const BouncingScrollPhysics(),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+            decoration: BoxDecoration(
+              color: betterPlayerControlsConfiguration.overflowModalColor,
+              /*shape: RoundedRectangleBorder(side: Bor,borderRadius: 24,)*/
+              borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(24.0),
+                  topRight: Radius.circular(24.0)),
+            ),
+            child: SafeArea(
+              top: false,
               child: Column(
                 children: children,
               ),
@@ -489,18 +489,18 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
           betterPlayerController?.betterPlayerConfiguration.useRootNavigator ??
               false,
       builder: (context) {
-        return SafeArea(
-          top: false,
-          child: SingleChildScrollView(
-            physics: const BouncingScrollPhysics(),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-              decoration: BoxDecoration(
-                color: betterPlayerControlsConfiguration.overflowModalColor,
-                borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(24.0),
-                    topRight: Radius.circular(24.0)),
-              ),
+        return SingleChildScrollView(
+          physics: const BouncingScrollPhysics(),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+            decoration: BoxDecoration(
+              color: betterPlayerControlsConfiguration.overflowModalColor,
+              borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(24.0),
+                  topRight: Radius.circular(24.0)),
+            ),
+            child: SafeArea(
+              top: false,
               child: Column(
                 children: children,
               ),

--- a/lib/src/controls/better_player_controls_state.dart
+++ b/lib/src/controls/better_player_controls_state.dart
@@ -452,7 +452,6 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
 
   void _showCupertinoModalBottomSheet(List<Widget> children) {
     showCupertinoModalPopup<void>(
-      barrierColor: Colors.transparent,
       context: context,
       useRootNavigator:
           betterPlayerController?.betterPlayerConfiguration.useRootNavigator ??
@@ -483,7 +482,6 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
 
   void _showMaterialBottomSheet(List<Widget> children) {
     showModalBottomSheet<void>(
-      backgroundColor: Colors.transparent,
       context: context,
       useRootNavigator:
           betterPlayerController?.betterPlayerConfiguration.useRootNavigator ??

--- a/lib/src/controls/better_player_controls_state.dart
+++ b/lib/src/controls/better_player_controls_state.dart
@@ -463,10 +463,8 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
             padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
             decoration: BoxDecoration(
               color: betterPlayerControlsConfiguration.overflowModalColor,
-              /*shape: RoundedRectangleBorder(side: Bor,borderRadius: 24,)*/
-              borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(24.0),
-                  topRight: Radius.circular(24.0)),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(24.0)),
             ),
             child: SafeArea(
               top: false,
@@ -493,9 +491,8 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
             padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
             decoration: BoxDecoration(
               color: betterPlayerControlsConfiguration.overflowModalColor,
-              borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(24.0),
-                  topRight: Radius.circular(24.0)),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(24.0)),
             ),
             child: SafeArea(
               top: false,


### PR DESCRIPTION
- Fix SafeArea cropping background of ModalBottomSheet.
- Reenable barrierColor (strange choice here, if the user doesn't want it he can change ThemeData, if the barrierColor is set explicitly to transparent the user cannot change that).

| Before                                                                                                           | After                                                                                                           |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![before](https://user-images.githubusercontent.com/38794405/149702806-5f828380-8037-4737-8c70-b0be536e4f19.jpg) | ![after](https://user-images.githubusercontent.com/38794405/149702799-adf78c2e-aa52-4235-8b51-27a07e26355f.jpg) |

