### PR TITLE
Bug fix for https://github.com/jhomlala/betterplayer/issues/989

### DIFF
--- a/ios/Classes/CacheManager.swift
+++ b/ios/Classes/CacheManager.swift
@@ -116,13 +116,13 @@ import PINCache
                 let mimeTypeResult = getMimeType(url:url, explicitVideoExtension: videoExtension)
                 if (mimeTypeResult.1.isEmpty){
                     NSLog("Cache error: couldn't find mime type for url: \(url.absoluteURL). For this URL cache didn't work and video will be played without cache.")
-                    playerItem = CachingPlayerItem(url: url, cacheKey: _key, headers: headers)
+                    playerItem = CachingPlayerItem(url: url, customFileExtension: videoExtension, cacheKey: _key, headers: headers)
                 } else {
                     playerItem = CachingPlayerItem(data: data!, mimeType: mimeTypeResult.1, fileExtension: mimeTypeResult.0)
                 }
             } else {
                 // The file is not cached.
-                playerItem = CachingPlayerItem(url: url, cacheKey: _key, headers: headers)
+                playerItem = CachingPlayerItem(url: url, customFileExtension: videoExtension, cacheKey: _key, headers: headers)
                 self._existsInStorage = false
             }
         }

--- a/ios/Classes/CachingPlayerItem.swift
+++ b/ios/Classes/CachingPlayerItem.swift
@@ -39,6 +39,7 @@ open class CachingPlayerItem: AVPlayerItem {
     class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSessionDelegate, URLSessionDataDelegate, URLSessionTaskDelegate {
         
         var playingFromData = false
+        var originalURL: URL?
         var mimeType: String? // is required when playing from Data
         var session: URLSession?
         var headers: Dictionary<NSObject,AnyObject>?
@@ -67,7 +68,7 @@ open class CachingPlayerItem: AVPlayerItem {
             let configuration = URLSessionConfiguration.default
             configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-            var request = URLRequest(url: url)
+            var request = URLRequest(url: self.originalURL ?? url)
             request.httpMethod = "GET"
             let headersString = self.headers as? [String:AnyObject]
             if let unwrappedDict = headersString {
@@ -221,6 +222,7 @@ open class CachingPlayerItem: AVPlayerItem {
             urlWithCustomScheme.deletePathExtension()
             urlWithCustomScheme.appendPathExtension(ext)
             self.customFileExtension = ext
+            self.resourceLoaderDelegate.originalURL = url
         }
         
         let asset = AVURLAsset(url: urlWithCustomScheme)


### PR DESCRIPTION
AVURLAsset is particular about network resources without a file extension (e.g. https://fake.dom/HASH). Normally if there is no extension it falls back on the Content-Type. However if a AVAssetResourceLoaderDelegate is used with the AVURLAsset it fails to see the Content-Type of the resource. I suspect that since the delegate manages the URL response, the AVURLAsset never gets the Content-Type and fails. There should be a way to pass this information to the AVURLAsset using the delegate, but for the time being the cleanest working solution is just including the ext in the phony URL already given to the AVURLAsset (which is available due to how BetterPlayer's caching works).