### PR TITLE
android: Do not attempt to fetch notification icon if 'imageUrl' is not set

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
@@ -239,7 +239,7 @@ internal class BetterPlayer(
                 player: Player,
                 callback: BitmapCallback
             ): Bitmap? {
-                if (imageUrl == null) {
+                if (imageUrl.isNullOrEmpty()) {
                     return null
                 }
                 if (bitmap != null) {

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -368,7 +368,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 if (showNotification) {
                     val title = getParameter(dataSource, TITLE_PARAMETER, "")
                     val author = getParameter(dataSource, AUTHOR_PARAMETER, "")
-                    val imageUrl = getParameter(dataSource, IMAGE_URL_PARAMETER, "")
+                    val imageUrl = getParameter(dataSource, IMAGE_URL_PARAMETER, null)
                     val notificationChannelName =
                         getParameter<String?>(dataSource, NOTIFICATION_CHANNEL_NAME_PARAMETER, null)
                     val activityName =


### PR DESCRIPTION
When 'imageUrl' in notification configuration is not set the android platform code attempts to load the icon. The following error messages can be seen in the log output:

E/BitmapFactory( 9181): Unable to decode stream: java.io.FileNotFoundException: : open failed: ENOENT (No such file or directory)
I/WM-WorkerWrapper( 9181): Worker result FAILURE for Work [ id=cc135255-9dac-421c-a50c-7467d40166e9, tags={ , com.jhomlala.better_player.ImageWorker } ]