### PR TITLE
Remove redundant MediaSession callback

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
@@ -622,12 +622,6 @@ internal class BetterPlayer(
                 PendingIntent.FLAG_IMMUTABLE
             )
             val mediaSession = MediaSessionCompat(context, TAG, null, pendingIntent)
-            mediaSession.setCallback(object : MediaSessionCompat.Callback() {
-                override fun onSeekTo(pos: Long) {
-                    sendSeekToEvent(pos)
-                    super.onSeekTo(pos)
-                }
-            })
             mediaSession.isActive = true
             val mediaSessionConnector = MediaSessionConnector(mediaSession)
             mediaSessionConnector.setPlayer(exoPlayer)
@@ -719,14 +713,6 @@ internal class BetterPlayer(
 
             trackSelector.setParameters(builder)
         }
-    }
-
-    private fun sendSeekToEvent(positionMs: Long) {
-        exoPlayer?.seekTo(positionMs)
-        val event: MutableMap<String, Any> = HashMap()
-        event["event"] = "seek"
-        event["position"] = positionMs
-        eventSink.success(event)
     }
 
     fun setMixWithOthers(mixWithOthers: Boolean) {


### PR DESCRIPTION
ExoPlayer's MediaSessionConnector replaces our MediaSession callback with its own.