### PR TITLE
Add swift_versions to iOS podspec

### DIFF
--- a/ios/better_player.podspec
+++ b/ios/better_player.podspec
@@ -21,6 +21,7 @@ A new flutter plugin project.
   s.dependency 'PINCache'
   
   s.platform = :ios, '11.0'
+  s.swift_versions = ['5.0']
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
 


### PR DESCRIPTION
Trying to call `flutter build ios-framework` fails without a Swift version defined, so we need to add this.