### PR TITLE
Fix deprecated TextTheme properties: bodyText1 and button

### DIFF
--- a/lib/src/configuration/better_player_controls_configuration.dart
+++ b/lib/src/configuration/better_player_controls_configuration.dart
@@ -240,8 +240,8 @@ class BetterPlayerControlsConfiguration {
   ///Setup BetterPlayerControlsConfiguration based on Theme options.
   factory BetterPlayerControlsConfiguration.theme(ThemeData theme) {
     return BetterPlayerControlsConfiguration(
-      textColor: theme.textTheme.bodyText1?.color ?? Colors.white,
-      iconsColor: theme.textTheme.button?.color ?? Colors.white,
+      textColor: theme.textTheme.bodyLarge?.color ?? Colors.white,
+      iconsColor: theme.textTheme.labelLarge?.color ?? Colors.white,
     );
   }
 }


### PR DESCRIPTION
This pull request updates the deprecated TextTheme properties **bodyText1** and **button** to bodyLarge and labelLarge respectively. These changes are necessary to ensure compatibility with the latest versions of Flutter, which have deprecated the older properties. This should fix build errors related to these deprecations.