### PR TITLE
Fixed:bodyText1 and button creating issue

### DIFF
--- a/lib/src/configuration/better_player_controls_configuration.dart
+++ b/lib/src/configuration/better_player_controls_configuration.dart
@@ -240,8 +240,8 @@ class BetterPlayerControlsConfiguration {
   ///Setup BetterPlayerControlsConfiguration based on Theme options.
   factory BetterPlayerControlsConfiguration.theme(ThemeData theme) {
     return BetterPlayerControlsConfiguration(
-      textColor: theme.textTheme.bodyText1?.color ?? Colors.white,
-      iconsColor: theme.textTheme.button?.color ?? Colors.white,
+      textColor: theme.textTheme.bodyLarge?.color ?? Colors.white,
+      iconsColor: theme.textTheme.labelLarge?.color ?? Colors.white,
     );
   }
 }


### PR DESCRIPTION
i just edited (better_player_controls_configuration.dart):
line:243     textColor: theme.textTheme.bodyText1?.color ?? Colors.white,
line:244      iconsColor: theme.textTheme.button?.color ?? Colors.white,

to
      textColor: theme.textTheme.bodyLarge?.color ?? Colors.white,
      iconsColor: theme.textTheme.labelLarge?.color ?? Colors.white,

if anyone having this issue they can fix this by changing these two lines.