### PR TITLE
Fix remove package="com.jhomlala.better_player" from the source androidmanifest.xml Error 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.jhomlala.better_player'
     compileSdkVersion 31
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.jhomlala.better_player">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
**### [Fix] Remove package="com.jhomlala.better_player" from AndroidManifest.xml**
**Issue**
The AndroidManifest.xml file in the better_player Flutter package contains package="com.jhomlala.better_player", which is an outdated way of defining the application package name. This causes build failures in recent versions of Flutter and Android projects.

**Fix**
Removed package="com.jhomlala.better_player" from AndroidManifest.xml.
Ensured that the manifest aligns with modern Android project structure, which inherits the package name from AndroidManifest.xml in the main app module.
**Impact**
Fixes the build issue preventing applications from compiling.
Ensures compatibility with the latest Flutter and Android build systems.
**Testing**
Successfully built and ran a sample Flutter project using better_player after applying the fix.
References
[Flutter Android Manifest Documentation](https://developer.android.com/guide/topics/manifest/manifest-intro)