### PR TITLE
[docs] Clarify platform-specific DASH/HLS support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,13 @@ This plugin is based on [Chewie](https://github.com/brianegan/chewie). Chewie is
 ✔️ HTTP Headers support  
 ✔️ BoxFit of video support  
 ✔️ Playback speed support  
-✔️ HLS support (track, subtitles (also segmented), audio track selection)  
-✔️ DASH support (track, subtitles, audio track selection)     
+✔️ HLS support (track, subtitles (also segmented), audio track selection)
+  • **Android:** Fully supported via ExoPlayer
+  • **iOS:** Fully supported and recommended (native AVPlayer)
+✔️ DASH support (track, subtitles, audio track selection)
+  • **Android:** Fully supported via ExoPlayer
+  • **iOS:** Limited native support due to AVPlayer's primary focus on HLS
+    ◦ Note: To play DASH on iOS, consider using a custom media player (e.g., via WebView) that supports MPEG-DASH
 ✔️ Alternative resolution support  
 ✔️ Cache support  
 ✔️ Notifications support  


### PR DESCRIPTION
## Description

This PR updates the README.md to provide clearer information regarding HLS and DASH support across different platforms (iOS and Android).

Currently, the README lists "DASH support" and "HLS support" without explicitly detailing platform-specific limitations or strengths. For instance, native AVPlayer on iOS has limited direct DASH support, while it's optimized for HLS. On Android, ExoPlayer robustly supports both.

This clarification aims to:
- Prevent confusion for developers regarding expected behavior on iOS vs. Android.
- Accurately reflect the underlying native player capabilities.

Closes #1407