### PR TITLE
Upstream/feature/agp8 fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.jhomlala.better_player"
     compileSdkVersion 31
 
     compileOptions {

--- a/lib/src/hls/hls_parser/drm_init_data.dart
+++ b/lib/src/hls/hls_parser/drm_init_data.dart
@@ -19,5 +19,5 @@ class DrmInitData {
   }
 
   @override
-  int get hashCode => hashValues(schemeType, schemeData);
+  int get hashCode => Object.hash(schemeType, schemeData);
 }

--- a/lib/src/hls/hls_parser/hls_track_metadata_entry.dart
+++ b/lib/src/hls/hls_parser/hls_track_metadata_entry.dart
@@ -28,5 +28,6 @@ class HlsTrackMetadataEntry {
   }
 
   @override
-  int get hashCode => hashValues(groupId, name, variantInfos);
+  int get hashCode =>
+      Object.hash(groupId, name, Object.hashAll(variantInfos ?? []));
 }

--- a/lib/src/hls/hls_parser/scheme_data.dart
+++ b/lib/src/hls/hls_parser/scheme_data.dart
@@ -49,10 +49,10 @@ class SchemeData {
   }
 
   @override
-  int get hashCode => hashValues(
-      /*uuid, */
-      licenseServerUrl,
-      mimeType,
-      data,
-      requiresSecureDecryption);
+  int get hashCode => Object.hash(
+        licenseServerUrl,
+        mimeType,
+        data,
+        requiresSecureDecryption,
+      );
 }

--- a/lib/src/hls/hls_parser/variant_info.dart
+++ b/lib/src/hls/hls_parser/variant_info.dart
@@ -41,6 +41,6 @@ class VariantInfo {
   }
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
       bitrate, videoGroupId, audioGroupId, subtitleGroupId, captionGroupId);
 }


### PR DESCRIPTION
Use fix(android) because it's a fix in the Android-specific part of the plugin.
fix(android): add namespace to support AGP 8.0+

Use refactor because functionality remains the same, but code is modernized.
Mention Dart 3/Flutter 3 compatibility for clarity.
refactor: replace deprecated `hashValues` with `Object.hash` for Dart 3 compatibility