### PR TITLE
Flutter 3.47 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.2.2
+* Fixed: Unreliable video and image URLs in the example app, especially on the Playlist page. Replaced them with stable ones from Google GTV bucket and Lorem Picsum.
+
 ## 0.2.1
 * Added: `.pubignore` to exclude `media/` and `AGENTS.md` from the published package.
 * Updated: Documentation and README links to point to the new media location on GitHub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [BREAKING_CHANGE] Migrated Material and Cupertino UI systems to standalone `material_ui` and `cupertino_ui` packages.
 * Updated `compileSdkVersion` to 36 in Android.
 * Updated Kotlin version to 2.3.20 in the example app.
+* Updated Android Gradle Plugin version to 9.0.1 in the example app.
 
 ## 0.2.1
 * Added: `.pubignore` to exclude `media/` and `AGENTS.md` from the published package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 * Updated `compileSdkVersion` to 36 in Android.
 * Updated Kotlin version to 2.3.20 in the example app.
 
-* Fixed: Unreliable video and image URLs in the example app, especially on the Playlist page. Replaced them with stable ones from Google GTV bucket and Lorem Picsum.
-
 ## 0.2.1
 * Added: `.pubignore` to exclude `media/` and `AGENTS.md` from the published package.
 * Updated: Documentation and README links to point to the new media location on GitHub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [BREAKING_CHANGE] Migrated to Flutter 3.47.0.
 * [BREAKING_CHANGE] Migrated Material and Cupertino UI systems to standalone `material_ui` and `cupertino_ui` packages.
 * Updated `compileSdkVersion` to 36 in Android.
+* Updated Kotlin version to 2.3.20 in the example app.
 
 * Fixed: Unreliable video and image URLs in the example app, especially on the Playlist page. Replaced them with stable ones from Google GTV bucket and Lorem Picsum.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
-## 0.2.2
+## 0.3.0
+* [BREAKING_CHANGE] Migrated to Flutter 3.47.0.
+* [BREAKING_CHANGE] Migrated Material and Cupertino UI systems to standalone `material_ui` and `cupertino_ui` packages.
+* Updated `compileSdkVersion` to 36 in Android.
+
 * Fixed: Unreliable video and image URLs in the example app, especially on the Playlist page. Replaced them with stable ones from Google GTV bucket and Lorem Picsum.
 
 ## 0.2.1

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,14 @@ analyzer:
     unreachable_switch_default: ignore
     unused_import: ignore
     deprecated_member_use: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace "com.jhomlala.better_player"
-    compileSdkVersion 34
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_21

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -14,6 +14,14 @@ analyzer:
     undefined_lint: ignore
     strict_raw_type: ignore
     inference_failure_on_function_return_type: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.11.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.20" apply false
 }
 
 include ":app"

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.11.1" apply false
+    id "com.android.application" version "9.0.1" apply false
     id "org.jetbrains.kotlin.android" version "2.3.20" apply false
 }
 

--- a/example/lib/constants.dart
+++ b/example/lib/constants.dart
@@ -9,34 +9,33 @@ class Constants {
       'https://github.com/tinusneethling/betterplayer/raw/ClearKeySupport/example/assets/testvideo_encrypt.mp4';
   static const String fileExampleSubtitlesUrl = 'example_subtitles.srt';
   static const String hlsTestStreamUrl =
-      'https://mtoczko.github.io/hls-test-streams/test-group/playlist.m3u8';
+      'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
   static const String hlsPlaylistUrl =
-      'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8';
+      'https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8';
   static const Map<String, String> exampleResolutionsUrls = {
     'LOW':
-        'https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_480_1_5MG.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
     'MEDIUM':
-        'https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_640_3MG.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
     'LARGE':
-        'https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_1280_10MG.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4',
     'EXTRA_LARGE':
-        'https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_1920_18MG.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
   };
   static const String phantomVideoUrl =
-      'http://sample.vodobox.com/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8';
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4';
   static const String elephantDreamVideoUrl =
-      'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4';
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4';
   static const String forBiggerJoyridesVideoUrl =
-      'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4';
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4';
   static const String verticalVideoUrl =
-      'http://www.exit109.com/~dnn/clips/RW20seconds_1.mp4';
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4';
   static String logo = 'logo.png';
-  static String placeholderUrl =
-      'https://imgix.bustle.com/uploads/image/2020/8/5/23905b9c-6b8c-47fa-bc0f-434de1d7e9bf-avengers-5.jpg';
+  static String placeholderUrl = 'https://picsum.photos/id/10/1000/1000';
   static String elephantDreamStreamUrl =
-      'http://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8';
+      'https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8';
   static String tokenEncodedHlsUrl =
-      'https://amssamples.streaming.mediaservices.windows.net/830584f8-f0c8-4e41-968b-6538b9380aa5/TearsOfSteelTeaser.ism/manifest(format=m3u8-aapl)';
+      'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8';
   static String tokenEncodedHlsToken =
       'Bearer=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1cm46bWljcm9zb2Z0OmF6dXJlOm1lZGlhc2VydmljZXM6Y29udGVudGtleWlkZW50aWZpZXIiOiI5ZGRhMGJjYy01NmZiLTQxNDMtOWQzMi0zYWI5Y2M2ZWE4MGIiLCJpc3MiOiJodHRwOi8vdGVzdGFjcy5jb20vIiwiYXVkIjoidXJuOnRlc3QiLCJleHAiOjE3MTA4MDczODl9.lJXm5hmkp5ArRIAHqVJGefW2bcTzd91iZphoKDwa6w8';
   static String widevineVideoUrl =
@@ -48,10 +47,9 @@ class Constants {
   static String fairplayCertificateUrl =
       'https://github.com/koldo92/betterplayer/raw/fairplay_ezdrm/example/assets/eleisure.cer';
   static String fairplayLicenseUrl = 'https://fps.ezdrm.com/api/licenses/';
-  static String catImageUrl =
-      'https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/cat_relaxing_on_patio_other/1800x1200_cat_relaxing_on_patio_other.jpg';
+  static String catImageUrl = 'https://picsum.photos/id/237/1000/1000';
   static String dashStreamUrl =
-      'https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd';
+      'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd';
   static String segmentedSubtitlesHlsUrl =
       'https://eng-demo.cablecast.tv/segmented-captions/vod.m3u8';
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:example/pages/welcome_page.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart'
+    hide GlobalMaterialLocalizations;
+import 'package:material_ui/material_ui.dart';
 
 void main() => runApp(const MyApp());
 

--- a/example/lib/pages/auto_fullscreen_orientation_page.dart
+++ b/example/lib/pages/auto_fullscreen_orientation_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class AutoFullscreenOrientationPage extends StatefulWidget {
   const AutoFullscreenOrientationPage({super.key});

--- a/example/lib/pages/basic_player_page.dart
+++ b/example/lib/pages/basic_player_page.dart
@@ -1,7 +1,7 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
 import 'package:example/utils.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BasicPlayerPage extends StatefulWidget {
   const BasicPlayerPage({super.key});

--- a/example/lib/pages/cache_page.dart
+++ b/example/lib/pages/cache_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class CachePage extends StatefulWidget {
   const CachePage({super.key});

--- a/example/lib/pages/clearkey_page.dart
+++ b/example/lib/pages/clearkey_page.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
 import 'package:example/utils.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ClearKeyPage extends StatefulWidget {
   const ClearKeyPage({super.key});

--- a/example/lib/pages/controller_controls_page.dart
+++ b/example/lib/pages/controller_controls_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ControllerControlsPage extends StatefulWidget {
   const ControllerControlsPage({super.key});

--- a/example/lib/pages/controls_always_visible_page.dart
+++ b/example/lib/pages/controls_always_visible_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ControlsAlwaysVisiblePage extends StatefulWidget {
   const ControlsAlwaysVisiblePage({super.key});

--- a/example/lib/pages/controls_configuration_page.dart
+++ b/example/lib/pages/controls_configuration_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ControlsConfigurationPage extends StatefulWidget {
   const ControlsConfigurationPage({super.key});

--- a/example/lib/pages/custom_controls/change_player_theme_page.dart
+++ b/example/lib/pages/custom_controls/change_player_theme_page.dart
@@ -1,7 +1,7 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
 import 'package:example/pages/custom_controls/custom_controls_widget.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ChangePlayerThemePage extends StatefulWidget {
   const ChangePlayerThemePage({super.key});

--- a/example/lib/pages/custom_controls/custom_controls_widget.dart
+++ b/example/lib/pages/custom_controls/custom_controls_widget.dart
@@ -1,5 +1,5 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class CustomControlsWidget extends StatefulWidget {
   const CustomControlsWidget({

--- a/example/lib/pages/dash_page.dart
+++ b/example/lib/pages/dash_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class DashPage extends StatefulWidget {
   const DashPage({super.key});

--- a/example/lib/pages/drm_page.dart
+++ b/example/lib/pages/drm_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class DrmPage extends StatefulWidget {
   const DrmPage({super.key});

--- a/example/lib/pages/event_listener_page.dart
+++ b/example/lib/pages/event_listener_page.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class EventListenerPage extends StatefulWidget {
   const EventListenerPage({super.key});

--- a/example/lib/pages/fade_placeholder_page.dart
+++ b/example/lib/pages/fade_placeholder_page.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class FadePlaceholderPage extends StatefulWidget {
   const FadePlaceholderPage({super.key});

--- a/example/lib/pages/hls_audio_page.dart
+++ b/example/lib/pages/hls_audio_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class HlsAudioPage extends StatefulWidget {
   const HlsAudioPage({super.key});

--- a/example/lib/pages/hls_subtitles_page.dart
+++ b/example/lib/pages/hls_subtitles_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class HlsSubtitlesPage extends StatefulWidget {
   const HlsSubtitlesPage({super.key});

--- a/example/lib/pages/hls_tracks_page.dart
+++ b/example/lib/pages/hls_tracks_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class HlsTracksPage extends StatefulWidget {
   const HlsTracksPage({super.key});

--- a/example/lib/pages/memory_player_page.dart
+++ b/example/lib/pages/memory_player_page.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
 import 'package:example/utils.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class MemoryPlayerPage extends StatefulWidget {
   const MemoryPlayerPage({super.key});

--- a/example/lib/pages/normal_player_page.dart
+++ b/example/lib/pages/normal_player_page.dart
@@ -1,7 +1,7 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 class NormalPlayerPage extends StatefulWidget {
   const NormalPlayerPage({super.key});

--- a/example/lib/pages/notification_player_page.dart
+++ b/example/lib/pages/notification_player_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class NotificationPlayerPage extends StatefulWidget {
   const NotificationPlayerPage({super.key});

--- a/example/lib/pages/overridden_aspect_ratio_page.dart
+++ b/example/lib/pages/overridden_aspect_ratio_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class OverriddenAspectRatioPage extends StatefulWidget {
   const OverriddenAspectRatioPage({super.key});

--- a/example/lib/pages/overriden_duration_page.dart
+++ b/example/lib/pages/overriden_duration_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class OverriddenDurationPage extends StatefulWidget {
   const OverriddenDurationPage({super.key});

--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PictureInPicturePage extends StatefulWidget {
   const PictureInPicturePage({super.key});

--- a/example/lib/pages/placeholder_until_play_page.dart
+++ b/example/lib/pages/placeholder_until_play_page.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PlaceholderUntilPlayPage extends StatefulWidget {
   const PlaceholderUntilPlayPage({super.key});

--- a/example/lib/pages/playlist_page.dart
+++ b/example/lib/pages/playlist_page.dart
@@ -1,8 +1,8 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
 import 'package:example/utils.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PlaylistPage extends StatefulWidget {
   const PlaylistPage({super.key});

--- a/example/lib/pages/resolutions_page.dart
+++ b/example/lib/pages/resolutions_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ResolutionsPage extends StatefulWidget {
   const ResolutionsPage({super.key});

--- a/example/lib/pages/reusable_video_list/reusable_video_list_page.dart
+++ b/example/lib/pages/reusable_video_list/reusable_video_list_page.dart
@@ -4,7 +4,7 @@ import 'package:example/constants.dart';
 import 'package:example/model/video_list_data.dart';
 import 'package:example/pages/reusable_video_list/reusable_video_list_controller.dart';
 import 'package:example/pages/reusable_video_list/reusable_video_list_widget.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ReusableVideoListPage extends StatefulWidget {
   const ReusableVideoListPage({super.key});

--- a/example/lib/pages/reusable_video_list/reusable_video_list_widget.dart
+++ b/example/lib/pages/reusable_video_list/reusable_video_list_widget.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:better_player/better_player.dart';
 import 'package:example/model/video_list_data.dart';
 import 'package:example/pages/reusable_video_list/reusable_video_list_controller.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 class ReusableVideoListWidget extends StatefulWidget {

--- a/example/lib/pages/rotation_and_fit_page.dart
+++ b/example/lib/pages/rotation_and_fit_page.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class RotationAndFitPage extends StatefulWidget {
   const RotationAndFitPage({super.key});

--- a/example/lib/pages/subtitles_page.dart
+++ b/example/lib/pages/subtitles_page.dart
@@ -1,7 +1,7 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/constants.dart';
 import 'package:example/utils.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class SubtitlesPage extends StatefulWidget {
   const SubtitlesPage({super.key});

--- a/example/lib/pages/subtitles_page.dart
+++ b/example/lib/pages/subtitles_page.dart
@@ -39,7 +39,7 @@ class _SubtitlesPageState extends State<SubtitlesPage> {
   Future<void> _setupDataSource() async {
     final dataSource = BetterPlayerDataSource(
       BetterPlayerDataSourceType.network,
-      Constants.forBiggerBlazesUrl,
+      Constants.bugBuckBunnyVideoUrl,
       subtitles: BetterPlayerSubtitlesSource.single(
         type: BetterPlayerSubtitlesSourceType.file,
         url: await Utils.getFileUrl(Constants.fileExampleSubtitlesUrl),

--- a/example/lib/pages/video_list/video_list_page.dart
+++ b/example/lib/pages/video_list/video_list_page.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'package:example/constants.dart';
 import 'package:example/model/video_list_data.dart';
 import 'package:example/pages/video_list/video_list_widget.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class VideoListPage extends StatefulWidget {
   const VideoListPage({super.key});

--- a/example/lib/pages/video_list/video_list_widget.dart
+++ b/example/lib/pages/video_list/video_list_widget.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:example/model/video_list_data.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class VideoListWidget extends StatefulWidget {
   const VideoListWidget({super.key, this.videoListData});

--- a/example/lib/pages/welcome_page.dart
+++ b/example/lib/pages/welcome_page.dart
@@ -29,8 +29,8 @@ import 'package:example/pages/reusable_video_list/reusable_video_list_page.dart'
 import 'package:example/pages/rotation_and_fit_page.dart';
 import 'package:example/pages/subtitles_page.dart';
 import 'package:example/pages/video_list/video_list_page.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path_provider/path_provider.dart';
 
 class WelcomePage extends StatefulWidget {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.2.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -88,6 +88,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: "direct main"
+    description:
+      name: cupertino_ui
+      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dbus:
     dependency: transitive
     description:
@@ -184,10 +192,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   jni:
     dependency: transitive
     description:
@@ -248,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -260,14 +268,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: d9b4f6c69b80bc83d0a14357c86e4c14c8076e807ae73cf2960c8560f623995f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   objective_c:
     dependency: transitive
     description:
@@ -445,10 +461,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -461,10 +477,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   very_good_analysis:
     dependency: "direct dev"
     description:
@@ -546,5 +562,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.47.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,12 +4,15 @@ publish_to: 'none'
 version: 1.0.0+1
 environment:
   sdk: '>=3.4.1 <4.0.0'
+  flutter: '>=3.47.0'
 
 dependencies:
   better_player:
     path: ../
   flutter:
     sdk: flutter
+  material_ui: ^1.0.0
+  cupertino_ui: ^1.0.0
   flutter_localizations:
     sdk: flutter
   path_provider: ^2.1.3

--- a/ios/better_player.podspec
+++ b/ios/better_player.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'better_player'
-  s.version          = '0.2.2'
+  s.version          = '0.3.0'
   s.summary          = 'Advanced video player with HLS, DASH and caching support.'
   s.description      = <<-DESC
 Advanced video player for Flutter with HLS, DASH and caching support.

--- a/ios/better_player.podspec
+++ b/ios/better_player.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'better_player'
-  s.version          = '0.2.1'
+  s.version          = '0.2.2'
   s.summary          = 'Advanced video player with HLS, DASH and caching support.'
   s.description      = <<-DESC
 Advanced video player for Flutter with HLS, DASH and caching support.

--- a/lib/src/configuration/better_player_configuration.dart
+++ b/lib/src/configuration/better_player_configuration.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Configuration of Better Player. Allows to setup general behavior of player.
 ///Master configuration which contains children that configure specific part

--- a/lib/src/configuration/better_player_controls_configuration.dart
+++ b/lib/src/configuration/better_player_controls_configuration.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///UI configuration of Better Player. Allows to change colors/icons/behavior
 ///of controls. Used in BetterPlayerConfiguration. Configuration applies only

--- a/lib/src/controls/better_player_clickable_widget.dart
+++ b/lib/src/controls/better_player_clickable_widget.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerMaterialClickableWidget extends StatelessWidget {
   final Widget child;

--- a/lib/src/controls/better_player_controls_state.dart
+++ b/lib/src/controls/better_player_controls_state.dart
@@ -4,8 +4,8 @@ import 'package:better_player/better_player.dart';
 import 'package:better_player/src/controls/better_player_clickable_widget.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Base class for both material and cupertino controls
 abstract class BetterPlayerControlsState<T extends StatefulWidget>

--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -7,8 +7,8 @@ import 'package:better_player/src/controls/better_player_progress_colors.dart';
 import 'package:better_player/src/core/better_player_controller.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/video_player/video_player.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerCupertinoControls extends StatefulWidget {
   ///Callback used to send information if player bar is hidden or not

--- a/lib/src/controls/better_player_cupertino_progress_bar.dart
+++ b/lib/src/controls/better_player_cupertino_progress_bar.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:better_player/src/controls/better_player_progress_colors.dart';
 import 'package:better_player/src/core/better_player_controller.dart';
 import 'package:better_player/src/video_player/video_player.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerCupertinoVideoProgressBar extends StatefulWidget {
   BetterPlayerCupertinoVideoProgressBar(

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -10,7 +10,7 @@ import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/video_player/video_player.dart';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerMaterialControls extends StatefulWidget {
   ///Callback used to send information if player bar is hidden or not

--- a/lib/src/controls/better_player_material_progress_bar.dart
+++ b/lib/src/controls/better_player_material_progress_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/video_player/video_player.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerMaterialVideoProgressBar extends StatefulWidget {
   BetterPlayerMaterialVideoProgressBar(

--- a/lib/src/controls/better_player_multiple_gesture_detector.dart
+++ b/lib/src/controls/better_player_multiple_gesture_detector.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Helper class for GestureDetector used within Better Player. Used to pass
 ///gestures to upper GestureDetectors.

--- a/lib/src/controls/better_player_overflow_menu_item.dart
+++ b/lib/src/controls/better_player_overflow_menu_item.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Menu item data used in overflow menu (3 dots).
 class BetterPlayerOverflowMenuItem {

--- a/lib/src/core/better_player.dart
+++ b/lib/src/core/better_player.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
+
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/configuration/better_player_controller_event.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/core/better_player_with_controls.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -8,7 +8,7 @@ import 'package:better_player/src/subtitles/better_player_subtitles_factory.dart
 import 'package:better_player/src/video_player/video_player.dart';
 import 'package:better_player/src/video_player/video_player_platform_interface.dart';
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path_provider/path_provider.dart';
 
 ///Class used to control overall Better Player behavior. Main class to change

--- a/lib/src/core/better_player_controller_provider.dart
+++ b/lib/src/core/better_player_controller_provider.dart
@@ -1,5 +1,5 @@
 import 'package:better_player/src/core/better_player_controller.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Widget which is used to inherit BetterPlayerController through widget tree.
 class BetterPlayerControllerProvider extends InheritedWidget {

--- a/lib/src/core/better_player_utils.dart
+++ b/lib/src/core/better_player_utils.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerUtils {
   static String formatBitrate(int bitrate) {

--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -8,7 +8,7 @@ import 'package:better_player/src/controls/better_player_material_controls.dart'
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/subtitles/better_player_subtitles_drawer.dart';
 import 'package:better_player/src/video_player/video_player.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerWithControls extends StatefulWidget {
   final BetterPlayerController? controller;

--- a/lib/src/list/better_player_list_video_player.dart
+++ b/lib/src/list/better_player_list_video_player.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Special version of Better Player which is used to play video in list view.
 class BetterPlayerListVideoPlayer extends StatefulWidget {

--- a/lib/src/playlist/better_player_playlist.dart
+++ b/lib/src/playlist/better_player_playlist.dart
@@ -2,7 +2,7 @@ import 'package:better_player/better_player.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Special version of Better Player used to play videos in playlist.
 class BetterPlayerPlaylist extends StatefulWidget {

--- a/lib/src/subtitles/better_player_subtitles_configuration.dart
+++ b/lib/src/subtitles/better_player_subtitles_configuration.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Configuration of subtitles - colors/padding/font. Used in
 ///BetterPlayerConfiguration.

--- a/lib/src/subtitles/better_player_subtitles_drawer.dart
+++ b/lib/src/subtitles/better_player_subtitles_drawer.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
+
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/subtitles/better_player_subtitle.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerSubtitlesDrawer extends StatefulWidget {
   final List<BetterPlayerSubtitle> subtitles;

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -5,13 +5,11 @@
 // Dart imports:
 import 'dart:async';
 import 'dart:io';
-import 'package:better_player/better_player.dart' show VideoPlayerValue;
+
 import 'package:better_player/src/configuration/better_player_buffering_configuration.dart';
-import 'package:better_player/src/video_player/video_player.dart'
-    show VideoPlayerController, VideoPlayerValue;
 import 'package:better_player/src/video_player/video_player_platform_interface.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 final VideoPlayerPlatform _videoPlayerPlatform = VideoPlayerPlatform.instance
 // This will clear all open videos on the platform when a full restart is

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: "direct main"
+    description:
+      name: cupertino_ui
+      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dbus:
     dependency: transitive
     description:
@@ -177,10 +185,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   jni:
     dependency: transitive
     description:
@@ -241,10 +249,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -253,14 +261,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: d9b4f6c69b80bc83d0a14357c86e4c14c8076e807ae73cf2960c8560f623995f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   objective_c:
     dependency: transitive
     description:
@@ -438,10 +454,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -454,10 +470,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   very_good_analysis:
     dependency: "direct dev"
     description:
@@ -540,4 +556,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.41.0"
+  flutter: ">=3.47.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,18 @@
 name: better_player
 description: Advanced video player. It solves many typical use cases and it's easy to run.
-version: 0.2.2
+version: 0.3.0
 homepage: https://github.com/jhomlala/betterplayer
 documentation: https://jhomlala.github.io/betterplayer/
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.47.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^1.0.0
+  cupertino_ui: ^1.0.0
   cupertino_icons: ^1.0.8
   wakelock_plus: ^1.7.0
   meta: ^1.18.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_player
 description: Advanced video player. It solves many typical use cases and it's easy to run.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/jhomlala/betterplayer
 documentation: https://jhomlala.github.io/betterplayer/
 

--- a/test/configuration/better_player_configurations_test.dart
+++ b/test/configuration/better_player_configurations_test.dart
@@ -1,7 +1,7 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('BetterPlayer Configuration tests', () {

--- a/test/controls/better_player_controls_state_test.dart
+++ b/test/controls/better_player_controls_state_test.dart
@@ -1,7 +1,8 @@
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/video_player/video_player_platform_interface.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
 import '../helpers/better_player_mock_controller.dart';
 
 class MockControlsWidget extends StatefulWidget {

--- a/test/controls/better_player_controls_test.dart
+++ b/test/controls/better_player_controls_test.dart
@@ -1,10 +1,9 @@
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/controls/better_player_cupertino_progress_bar.dart';
-import 'package:better_player/src/controls/better_player_material_controls.dart';
 import 'package:better_player/src/controls/better_player_material_progress_bar.dart';
 import 'package:better_player/src/core/better_player_with_controls.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../helpers/better_player_mock_controller.dart';

--- a/test/controls/better_player_multiple_gesture_detector_test.dart
+++ b/test/controls/better_player_multiple_gesture_detector_test.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/src/controls/better_player_multiple_gesture_detector.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('BetterPlayerMultipleGestureDetector tests', () {

--- a/test/controls/better_player_overflow_menu_item_test.dart
+++ b/test/controls/better_player_overflow_menu_item_test.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/src/controls/better_player_overflow_menu_item.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   test('BetterPlayerOverflowMenuItem model test', () {

--- a/test/controls/better_player_progress_colors_test.dart
+++ b/test/controls/better_player_progress_colors_test.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/src/controls/better_player_progress_colors.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   test('BetterPlayerProgressColors test', () {

--- a/test/core/better_player_controller_advanced_test.dart
+++ b/test/core/better_player_controller_advanced_test.dart
@@ -1,5 +1,4 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/core/better_player_controller_test.dart
+++ b/test/core/better_player_controller_test.dart
@@ -1,8 +1,8 @@
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/configuration/better_player_controller_event.dart';
-import 'package:better_player/src/video_player/video_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
 import '../helpers/better_player_mock_controller.dart';
 import '../helpers/better_player_test_utils.dart';
 import '../helpers/mock_method_channel.dart';

--- a/test/core/better_player_test.dart
+++ b/test/core/better_player_test.dart
@@ -1,7 +1,8 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:visibility_detector/visibility_detector.dart';
+
 import '../helpers/better_player_mock_controller.dart';
 import '../helpers/better_player_test_utils.dart';
 

--- a/test/core/better_player_utils_test.dart
+++ b/test/core/better_player_utils_test.dart
@@ -1,8 +1,8 @@
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/dash/better_player_dash_utils.dart';
 import 'package:better_player/src/hls/better_player_hls_utils.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('BetterPlayerUtils tests', () {

--- a/test/core/better_player_with_controls_test.dart
+++ b/test/core/better_player_with_controls_test.dart
@@ -1,8 +1,9 @@
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/core/better_player_with_controls.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:visibility_detector/visibility_detector.dart';
+
 import '../helpers/better_player_mock_controller.dart';
 import '../helpers/better_player_test_utils.dart';
 

--- a/test/list/better_player_list_video_player_test.dart
+++ b/test/list/better_player_list_video_player_test.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../helpers/mock_method_channel.dart';

--- a/test/playlist/better_player_playlist_test.dart
+++ b/test/playlist/better_player_playlist_test.dart
@@ -1,6 +1,7 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
 import '../helpers/mock_method_channel.dart';
 
 void main() {

--- a/test/subtitles/better_player_subtitles_configuration_test.dart
+++ b/test/subtitles/better_player_subtitles_configuration_test.dart
@@ -1,6 +1,6 @@
 import 'package:better_player/better_player.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   test('BetterPlayerSubtitlesConfiguration default values', () {

--- a/test/subtitles/better_player_subtitles_drawer_test.dart
+++ b/test/subtitles/better_player_subtitles_drawer_test.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
+
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/subtitles/better_player_subtitle.dart';
 import 'package:better_player/src/subtitles/better_player_subtitles_drawer.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../helpers/better_player_test_utils.dart';
 import '../helpers/mock_video_player_controller.dart';


### PR DESCRIPTION
## 0.3.0
* [BREAKING_CHANGE] Migrated to Flutter 3.47.0.
* [BREAKING_CHANGE] Migrated Material and Cupertino UI systems to standalone `material_ui` and `cupertino_ui` packages.
* Updated `compileSdkVersion` to 36 in Android.
* Updated Kotlin version to 2.3.20 in the example app.
* Updated Android Gradle Plugin version to 9.0.1 in the example app.
