### PR TITLE
Refactor: Replace helper build methods with dedicated Widget classes 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@
   - Prefer single quotes over double quotes.
   - Require trailing commas for multi-line arguments and collections.
   - Maintain the existing suppressions in `analysis_options.yaml` for specific project needs (e.g., `public_member_api_docs: false`).
+  - **Named Parameters**: Use named parameters for all functions, methods, and constructors if:
+    - They have 2 or more parameters.
+    - They have only 1 parameter and that parameter is a `bool`.
 
 ## Testing
 - **Async Operations**: Always `await` asynchronous calls in tests (e.g., `setupDataSource`, `play`, `pause`, `seekTo`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## Unreleased
+## 0.5.0
 * Updated: Major architectural refactor of player controls and UI components. Helper build methods (`_buildWidget()`) were replaced with dedicated Flutter `Widget` classes for improved modularity, performance, and maintainability.
 * Added: New granular widgets for Material and Cupertino controls, including top/bottom bars, hit areas, and status overlays.
 * Added: Isolated component testing suite for refactored widgets to improve UI reliability and coverage.
 * Updated: Applied project-wide coding standard for named parameters (required for 2+ arguments or 1 boolean argument).
 
-_## 0.4.3_
+## 0.4.3
 * Updated: Comprehensive documentation overhaul for professional tone, grammar, and typos across all project documentation.
 * Fixed: Documentation alert rendering by adding `docsify-plugin-flexible-alerts` plugin.
 * Added: Advanced accessibility support with localized labels and interactive semantics for controls and progress bar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Unreleased
 * Updated: Major architectural refactor of player controls and UI components. Helper build methods (`_buildWidget()`) were replaced with dedicated Flutter `Widget` classes for improved modularity, performance, and maintainability.
 * Added: New granular widgets for Material and Cupertino controls, including top/bottom bars, hit areas, and status overlays.
+* Added: Isolated component testing suite for refactored widgets to improve UI reliability and coverage.
 * Updated: Applied project-wide coding standard for named parameters (required for 2+ arguments or 1 boolean argument).
 
-## 0.4.3
+_## 0.4.3_
 * Updated: Comprehensive documentation overhaul for professional tone, grammar, and typos across all project documentation.
 * Fixed: Documentation alert rendering by adding `docsify-plugin-flexible-alerts` plugin.
 * Added: Advanced accessibility support with localized labels and interactive semantics for controls and progress bar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+* Updated: Major architectural refactor of player controls and UI components. Helper build methods (`_buildWidget()`) were replaced with dedicated Flutter `Widget` classes for improved modularity, performance, and maintainability.
+* Added: New granular widgets for Material and Cupertino controls, including top/bottom bars, hit areas, and status overlays.
+* Updated: Applied project-wide coding standard for named parameters (required for 2+ arguments or 1 boolean argument).
+
 ## 0.4.3
 * Updated: Comprehensive documentation overhaul for professional tone, grammar, and typos across all project documentation.
 * Fixed: Documentation alert rendering by adding `docsify-plugin-flexible-alerts` plugin.

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ Add `better_player` to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  better_player: ^0.4.3
+  better_player: ^0.5.0
 ```
 
 ## 2. Install Package
@@ -41,7 +41,7 @@ To ensure Better Player functions correctly on iOS, apply the following settings
 Apply the following settings for Android support:
 
 *   **SDK Version**: Set `compileSdkVersion` to **36**.
-*   **Flutter Version**: Use **Flutter 3.44.0** or higher (required for built-in Kotlin support).
+*   **Flutter Version**: Use **Flutter 3.47.0** or higher (required for latest architectural improvements).
 *   **MultiDex**: Ensure MultiDex is enabled in your project.
 
 ## 5. Additional Configurations (Optional)

--- a/example/lib/pages/fade_placeholder_page.dart
+++ b/example/lib/pages/fade_placeholder_page.dart
@@ -20,7 +20,7 @@ class _FadePlaceholderPageState extends State<FadePlaceholderPage> {
     final betterPlayerConfiguration = BetterPlayerConfiguration(
       aspectRatio: 16 / 9,
       fit: BoxFit.contain,
-      placeholder: _buildPlaceholder(),
+      placeholder: _FadePlaceholder(playStream: _playController.stream),
       showPlaceholderUntilPlay: true,
       placeholderOnTop: false,
     );
@@ -36,23 +36,6 @@ class _FadePlaceholderPageState extends State<FadePlaceholderPage> {
       }
     });
     super.initState();
-  }
-
-  Widget _buildPlaceholder() {
-    return StreamBuilder<bool>(
-      stream: _playController.stream,
-      builder: (context, snapshot) {
-        final showPlaceholder = snapshot.data ?? true;
-        return AnimatedOpacity(
-          duration: const Duration(milliseconds: 500),
-          opacity: showPlaceholder ? 1.0 : 0.0,
-          child: AspectRatio(
-            aspectRatio: 16 / 9,
-            child: Image.network(Constants.catImageUrl, fit: BoxFit.fill),
-          ),
-        );
-      },
-    );
   }
 
   @override
@@ -75,6 +58,30 @@ class _FadePlaceholderPageState extends State<FadePlaceholderPage> {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _FadePlaceholder extends StatelessWidget {
+  const _FadePlaceholder({required this.playStream});
+
+  final Stream<bool> playStream;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: playStream,
+      builder: (context, snapshot) {
+        final showPlaceholder = snapshot.data ?? true;
+        return AnimatedOpacity(
+          duration: const Duration(milliseconds: 500),
+          opacity: showPlaceholder ? 1.0 : 0.0,
+          child: AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Image.network(Constants.catImageUrl, fit: BoxFit.fill),
+          ),
+        );
+      },
     );
   }
 }

--- a/example/lib/pages/placeholder_until_play_page.dart
+++ b/example/lib/pages/placeholder_until_play_page.dart
@@ -28,7 +28,10 @@ class _PlaceholderUntilPlayPageState extends State<PlaceholderUntilPlayPage> {
   void initState() {
     final betterPlayerConfiguration = BetterPlayerConfiguration(
       fit: BoxFit.contain,
-      placeholder: _buildVideoPlaceholder(),
+      placeholder: _VideoPlaceholder(
+        placeholderStream: _placeholderStreamController.stream,
+        showPlaceholder: _showPlaceholder,
+      ),
       showPlaceholderUntilPlay: true,
     );
     final dataSource = BetterPlayerDataSource(
@@ -48,19 +51,6 @@ class _PlaceholderUntilPlayPageState extends State<PlaceholderUntilPlayPage> {
   void _setPlaceholderVisibleState(bool hidden) {
     _placeholderStreamController.add(hidden);
     _showPlaceholder = hidden;
-  }
-
-  ///_placeholderStreamController is used only to refresh video placeholder
-  ///widget.
-  Widget _buildVideoPlaceholder() {
-    return StreamBuilder<bool>(
-      stream: _placeholderStreamController.stream,
-      builder: (context, snapshot) {
-        return _showPlaceholder
-            ? Image.network(Constants.placeholderUrl)
-            : const SizedBox();
-      },
-    );
   }
 
   @override
@@ -83,6 +73,28 @@ class _PlaceholderUntilPlayPageState extends State<PlaceholderUntilPlayPage> {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _VideoPlaceholder extends StatelessWidget {
+  const _VideoPlaceholder({
+    required this.placeholderStream,
+    required this.showPlaceholder,
+  });
+
+  final Stream<bool> placeholderStream;
+  final bool showPlaceholder;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: placeholderStream,
+      builder: (context, snapshot) {
+        return (snapshot.data ?? showPlaceholder)
+            ? Image.network(Constants.placeholderUrl)
+            : const SizedBox();
+      },
     );
   }
 }

--- a/example/lib/pages/welcome_page.dart
+++ b/example/lib/pages/welcome_page.dart
@@ -75,109 +75,119 @@ class _WelcomePageState extends State<WelcomePage> {
 
   List<Widget> buildExampleElementWidgets() {
     return [
-      _buildExampleElementWidget('Basic player', () {
-        _navigateToPage(const BasicPlayerPage());
-      }),
-      _buildExampleElementWidget('Normal player', () {
-        _navigateToPage(const NormalPlayerPage());
-      }),
-      _buildExampleElementWidget('Controls configuration', () {
-        _navigateToPage(const ControlsConfigurationPage());
-      }),
-      _buildExampleElementWidget('Event listener', () {
-        _navigateToPage(const EventListenerPage());
-      }),
-      _buildExampleElementWidget('Subtitles', () {
-        _navigateToPage(const SubtitlesPage());
-      }),
-      _buildExampleElementWidget('Resolutions', () {
-        _navigateToPage(const ResolutionsPage());
-      }),
-      _buildExampleElementWidget('HLS tracks', () {
-        _navigateToPage(const HlsTracksPage());
-      }),
-      _buildExampleElementWidget('HLS subtitles', () {
-        _navigateToPage(const HlsSubtitlesPage());
-      }),
-      _buildExampleElementWidget('HLS Audio', () {
-        _navigateToPage(const HlsAudioPage());
-      }),
-      _buildExampleElementWidget('Cache', () {
-        _navigateToPage(const CachePage());
-      }),
-      _buildExampleElementWidget('Playlist', () {
-        _navigateToPage(const PlaylistPage());
-      }),
-      _buildExampleElementWidget('Video list', () {
-        _navigateToPage(const VideoListPage());
-      }),
-      _buildExampleElementWidget('Rotation and fit', () {
-        _navigateToPage(const RotationAndFitPage());
-      }),
-      _buildExampleElementWidget('Memory player', () {
-        _navigateToPage(const MemoryPlayerPage());
-      }),
-      _buildExampleElementWidget('Controller controls', () {
-        _navigateToPage(const ControllerControlsPage());
-      }),
-      _buildExampleElementWidget('Auto fullscreen orientation', () {
-        _navigateToPage(const AutoFullscreenOrientationPage());
-      }),
-      _buildExampleElementWidget('Overridden aspect ratio', () {
-        _navigateToPage(const OverriddenAspectRatioPage());
-      }),
-      _buildExampleElementWidget('Notifications player', () {
-        _navigateToPage(const NotificationPlayerPage());
-      }),
-      _buildExampleElementWidget('Picture in Picture', () {
-        _navigateToPage(const PictureInPicturePage());
-      }),
-      _buildExampleElementWidget('DRM', () {
-        _navigateToPage(const DrmPage());
-      }),
-      _buildExampleElementWidget('ClearKey DRM', () {
-        _navigateToPage(const ClearKeyPage());
-      }),
-      _buildExampleElementWidget('Dash', () {
-        _navigateToPage(const DashPage());
-      }),
-      _buildExampleElementWidget('Reusable video list', () {
-        _navigateToPage(const ReusableVideoListPage());
-      }),
-      _buildExampleElementWidget('Fade placeholder', () {
-        _navigateToPage(const FadePlaceholderPage());
-      }),
-      _buildExampleElementWidget('Placeholder until play', () {
-        _navigateToPage(const PlaceholderUntilPlayPage());
-      }),
-      _buildExampleElementWidget('Change player theme', () {
-        _navigateToPage(const ChangePlayerThemePage());
-      }),
-      _buildExampleElementWidget('Overridden duration', () {
-        _navigateToPage(const OverriddenDurationPage());
-      }),
-      _buildExampleElementWidget('Controls always visible', () {
-        _navigateToPage(const ControlsAlwaysVisiblePage());
-      }),
-    ];
-  }
-
-  Widget _buildExampleElementWidget(String name, Function onClicked) {
-    return Material(
-      child: InkWell(
-        onTap: onClicked as void Function()?,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              child: Text(name, style: const TextStyle(fontSize: 16)),
-            ),
-            const Divider(),
-          ],
-        ),
+      _WelcomePageItem(
+        name: 'Basic player',
+        onClicked: () => _navigateToPage(const BasicPlayerPage()),
       ),
-    );
+      _WelcomePageItem(
+        name: 'Normal player',
+        onClicked: () => _navigateToPage(const NormalPlayerPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Controls configuration',
+        onClicked: () => _navigateToPage(const ControlsConfigurationPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Event listener',
+        onClicked: () => _navigateToPage(const EventListenerPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Subtitles',
+        onClicked: () => _navigateToPage(const SubtitlesPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Resolutions',
+        onClicked: () => _navigateToPage(const ResolutionsPage()),
+      ),
+      _WelcomePageItem(
+        name: 'HLS tracks',
+        onClicked: () => _navigateToPage(const HlsTracksPage()),
+      ),
+      _WelcomePageItem(
+        name: 'HLS subtitles',
+        onClicked: () => _navigateToPage(const HlsSubtitlesPage()),
+      ),
+      _WelcomePageItem(
+        name: 'HLS Audio',
+        onClicked: () => _navigateToPage(const HlsAudioPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Cache',
+        onClicked: () => _navigateToPage(const CachePage()),
+      ),
+      _WelcomePageItem(
+        name: 'Playlist',
+        onClicked: () => _navigateToPage(const PlaylistPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Video list',
+        onClicked: () => _navigateToPage(const VideoListPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Rotation and fit',
+        onClicked: () => _navigateToPage(const RotationAndFitPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Memory player',
+        onClicked: () => _navigateToPage(const MemoryPlayerPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Controller controls',
+        onClicked: () => _navigateToPage(const ControllerControlsPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Auto fullscreen orientation',
+        onClicked: () => _navigateToPage(const AutoFullscreenOrientationPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Overridden aspect ratio',
+        onClicked: () => _navigateToPage(const OverriddenAspectRatioPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Notifications player',
+        onClicked: () => _navigateToPage(const NotificationPlayerPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Picture in Picture',
+        onClicked: () => _navigateToPage(const PictureInPicturePage()),
+      ),
+      _WelcomePageItem(
+        name: 'DRM',
+        onClicked: () => _navigateToPage(const DrmPage()),
+      ),
+      _WelcomePageItem(
+        name: 'ClearKey DRM',
+        onClicked: () => _navigateToPage(const ClearKeyPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Dash',
+        onClicked: () => _navigateToPage(const DashPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Reusable video list',
+        onClicked: () => _navigateToPage(const ReusableVideoListPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Fade placeholder',
+        onClicked: () => _navigateToPage(const FadePlaceholderPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Placeholder until play',
+        onClicked: () => _navigateToPage(const PlaceholderUntilPlayPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Change player theme',
+        onClicked: () => _navigateToPage(const ChangePlayerThemePage()),
+      ),
+      _WelcomePageItem(
+        name: 'Overridden duration',
+        onClicked: () => _navigateToPage(const OverriddenDurationPage()),
+      ),
+      _WelcomePageItem(
+        name: 'Controls always visible',
+        onClicked: () => _navigateToPage(const ControlsAlwaysVisiblePage()),
+      ),
+    ];
   }
 
   Future _navigateToPage(Widget page) async {
@@ -215,5 +225,31 @@ class _WelcomePageState extends State<WelcomePage> {
     final directory = await getApplicationDocumentsDirectory();
     final file = File('${directory.path}/${Constants.logo}');
     await file.writeAsBytes(content.buffer.asUint8List());
+  }
+}
+
+class _WelcomePageItem extends StatelessWidget {
+  const _WelcomePageItem({required this.name, required this.onClicked});
+
+  final String name;
+  final VoidCallback onClicked;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: InkWell(
+        onTap: onClicked,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(name, style: const TextStyle(fontSize: 16)),
+            ),
+            const Divider(),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.3"
+    version: "0.5.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/better_player.podspec
+++ b/ios/better_player.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'better_player'
-  s.version          = '0.4.3'
+  s.version          = '0.5.0'
   s.summary          = 'Advanced video player with HLS, DASH and caching support.'
   s.description      = <<-DESC
 Advanced video player for Flutter with HLS, DASH and caching support.

--- a/lib/src/controls/better_player_controls_state.dart
+++ b/lib/src/controls/better_player_controls_state.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 import 'dart:math';
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:better_player/src/controls/better_player_overflow_menu.dart';
+import 'package:better_player/src/controls/better_player_selection_list_item_widget.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:cupertino_ui/cupertino_ui.dart';
@@ -64,142 +66,45 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
   }
 
   void onShowMoreClicked() {
-    _showModalBottomSheet([_buildMoreOptionsList()]);
-  }
-
-  Widget _buildMoreOptionsList() {
-    final translations = betterPlayerController!.translations;
-    return SingleChildScrollView(
-      // ignore: avoid_unnecessary_containers
-      child: Container(
-        child: Column(
-          children: [
-            if (betterPlayerControlsConfiguration.enablePlaybackSpeed)
-              _buildMoreOptionsListRow(
-                betterPlayerControlsConfiguration.playbackSpeedIcon,
-                translations.overflowMenuPlaybackSpeed,
-                () {
-                  Navigator.of(context).pop();
-                  _showSpeedChooserWidget();
-                },
-              ),
-            if (betterPlayerControlsConfiguration.enableSubtitles)
-              _buildMoreOptionsListRow(
-                betterPlayerControlsConfiguration.subtitlesIcon,
-                translations.overflowMenuSubtitles,
-                () {
-                  Navigator.of(context).pop();
-                  _showSubtitlesSelectionWidget();
-                },
-              ),
-            if (betterPlayerControlsConfiguration.enableQualities)
-              _buildMoreOptionsListRow(
-                betterPlayerControlsConfiguration.qualitiesIcon,
-                translations.overflowMenuQuality,
-                () {
-                  Navigator.of(context).pop();
-                  _showQualitiesSelectionWidget();
-                },
-              ),
-            if (betterPlayerControlsConfiguration.enableAudioTracks)
-              _buildMoreOptionsListRow(
-                betterPlayerControlsConfiguration.audioTracksIcon,
-                translations.overflowMenuAudioTracks,
-                () {
-                  Navigator.of(context).pop();
-                  _showAudioTracksSelectionWidget();
-                },
-              ),
-            if (betterPlayerControlsConfiguration
-                .overflowMenuCustomItems
-                .isNotEmpty)
-              ...betterPlayerControlsConfiguration.overflowMenuCustomItems.map(
-                (customItem) => _buildMoreOptionsListRow(
-                  customItem.icon,
-                  customItem.title,
-                  () {
-                    Navigator.of(context).pop();
-                    customItem.onClicked.call();
-                  },
-                ),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMoreOptionsListRow(
-    IconData icon,
-    String name,
-    void Function() onTap,
-  ) {
-    return BetterPlayerMaterialClickableWidget(
-      onTap: onTap,
-      semanticsLabel: name,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-        child: Row(
-          children: [
-            const SizedBox(width: 8),
-            Icon(
-              icon,
-              color: betterPlayerControlsConfiguration.overflowMenuIconsColor,
-            ),
-            const SizedBox(width: 16),
-            Text(
-              name,
-              style: _getOverflowMenuElementTextStyle(false),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showSpeedChooserWidget() {
     _showModalBottomSheet([
-      _buildSpeedRow(0.25),
-      _buildSpeedRow(0.5),
-      _buildSpeedRow(0.75),
-      _buildSpeedRow(1),
-      _buildSpeedRow(1.25),
-      _buildSpeedRow(1.5),
-      _buildSpeedRow(1.75),
-      _buildSpeedRow(2),
+      BetterPlayerOverflowMenu(
+        controller: betterPlayerController!,
+        controlsConfiguration: betterPlayerControlsConfiguration,
+        onPlaybackSpeedClicked: () {
+          Navigator.of(context).pop();
+          _showSpeedChooserWidget();
+        },
+        onSubtitlesClicked: () {
+          Navigator.of(context).pop();
+          _showSubtitlesSelectionWidget();
+        },
+        onQualitiesClicked: () {
+          Navigator.of(context).pop();
+          _showQualitiesSelectionWidget();
+        },
+        onAudioTracksClicked: () {
+          Navigator.of(context).pop();
+          _showAudioTracksSelectionWidget();
+        },
+      ),
     ]);
   }
 
-  Widget _buildSpeedRow(double value) {
-    final isSelected =
-        betterPlayerController!.videoPlayerController!.value.speed == value;
-
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        Navigator.of(context).pop();
-        betterPlayerController!.setSpeed(value);
-      },
-      semanticsLabel: '$value x',
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        child: Row(
-          children: [
-            SizedBox(width: isSelected ? 8 : 16),
-            Visibility(
-              visible: isSelected,
-              child: Icon(
-                Icons.check_outlined,
-                color: betterPlayerControlsConfiguration.overflowModalTextColor,
-              ),
-            ),
-            const SizedBox(width: 16),
-            Text(
-              '$value x',
-              style: _getOverflowMenuElementTextStyle(isSelected),
-            ),
-          ],
-        ),
-      ),
+  void _showSpeedChooserWidget() {
+    _showModalBottomSheet(
+      [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0].map((speed) {
+        final isSelected =
+            betterPlayerController!.videoPlayerController!.value.speed == speed;
+        return BetterPlayerSelectionListItemWidget(
+          label: '$speed x',
+          isSelected: isSelected,
+          onTap: () {
+            Navigator.of(context).pop();
+            betterPlayerController!.setSpeed(speed);
+          },
+          controlsConfiguration: betterPlayerControlsConfiguration,
+        );
+      }).toList(),
     );
   }
 
@@ -248,49 +153,30 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
     }
 
     _showModalBottomSheet(
-      subtitles.map(_buildSubtitlesSourceRow).toList(),
-    );
-  }
+      subtitles.map((subtitlesSource) {
+        final selectedSourceType =
+            betterPlayerController!.betterPlayerSubtitlesSource;
+        final isSelected =
+            (subtitlesSource == selectedSourceType) ||
+            (subtitlesSource.type == BetterPlayerSubtitlesSourceType.none &&
+                subtitlesSource.type == selectedSourceType!.type);
 
-  Widget _buildSubtitlesSourceRow(BetterPlayerSubtitlesSource subtitlesSource) {
-    final selectedSourceType =
-        betterPlayerController!.betterPlayerSubtitlesSource;
-    final isSelected =
-        (subtitlesSource == selectedSourceType) ||
-        (subtitlesSource.type == BetterPlayerSubtitlesSourceType.none &&
-            subtitlesSource.type == selectedSourceType!.type);
+        final name =
+            subtitlesSource.type == BetterPlayerSubtitlesSourceType.none
+            ? betterPlayerController!.translations.generalNone
+            : subtitlesSource.name ??
+                  betterPlayerController!.translations.generalDefault;
 
-    final name = subtitlesSource.type == BetterPlayerSubtitlesSourceType.none
-        ? betterPlayerController!.translations.generalNone
-        : subtitlesSource.name ??
-              betterPlayerController!.translations.generalDefault;
-
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        Navigator.of(context).pop();
-        betterPlayerController!.setupSubtitleSource(subtitlesSource);
-      },
-      semanticsLabel: name,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        child: Row(
-          children: [
-            SizedBox(width: isSelected ? 8 : 16),
-            Visibility(
-              visible: isSelected,
-              child: Icon(
-                Icons.check_outlined,
-                color: betterPlayerControlsConfiguration.overflowModalTextColor,
-              ),
-            ),
-            const SizedBox(width: 16),
-            Text(
-              name,
-              style: _getOverflowMenuElementTextStyle(isSelected),
-            ),
-          ],
-        ),
-      ),
+        return BetterPlayerSelectionListItemWidget(
+          label: name,
+          isSelected: isSelected,
+          onTap: () {
+            Navigator.of(context).pop();
+            betterPlayerController!.setupSubtitleSource(subtitlesSource);
+          },
+          controlsConfiguration: betterPlayerControlsConfiguration,
+        );
+      }).toList(),
     );
   }
 
@@ -314,99 +200,67 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
             ? asmsTrackNames[index]
             : null;
       }
-      children.add(_buildTrackRow(asmsTracks[index], preferredName));
+
+      final width = track.width ?? 0;
+      final height = track.height ?? 0;
+      final bitrate = track.bitrate ?? 0;
+      final mimeType = (track.mimeType ?? '').replaceAll('video/', '');
+      final trackName =
+          preferredName ??
+          '${width}x$height ${BetterPlayerUtils.formatBitrate(bitrate)} $mimeType';
+
+      final selectedTrack = betterPlayerController!.betterPlayerAsmsTrack;
+      final isSelected = selectedTrack != null && selectedTrack == track;
+
+      children.add(
+        BetterPlayerSelectionListItemWidget(
+          label: trackName,
+          isSelected: isSelected,
+          onTap: () {
+            Navigator.of(context).pop();
+            betterPlayerController!.setTrack(track);
+          },
+          controlsConfiguration: betterPlayerControlsConfiguration,
+        ),
+      );
     }
 
     // normal videos
     final resolutions =
         betterPlayerController!.betterPlayerDataSource!.resolutions;
     resolutions?.forEach((key, value) {
-      children.add(_buildResolutionSelectionRow(key, value));
+      final isSelected =
+          value == betterPlayerController!.betterPlayerDataSource!.url;
+      children.add(
+        BetterPlayerSelectionListItemWidget(
+          label: key,
+          isSelected: isSelected,
+          onTap: () {
+            Navigator.of(context).pop();
+            betterPlayerController!.setResolution(value);
+          },
+          controlsConfiguration: betterPlayerControlsConfiguration,
+        ),
+      );
     });
 
     if (children.isEmpty) {
       children.add(
-        _buildTrackRow(
-          BetterPlayerAsmsTrack.defaultTrack(),
-          betterPlayerController!.translations.qualityAuto,
+        BetterPlayerSelectionListItemWidget(
+          label: betterPlayerController!.translations.qualityAuto,
+          isSelected: true,
+          onTap: () {
+            Navigator.of(context).pop();
+            betterPlayerController!.setTrack(
+              BetterPlayerAsmsTrack.defaultTrack(),
+            );
+          },
+          controlsConfiguration: betterPlayerControlsConfiguration,
         ),
       );
     }
 
     _showModalBottomSheet(children);
-  }
-
-  Widget _buildTrackRow(BetterPlayerAsmsTrack track, String? preferredName) {
-    final width = track.width ?? 0;
-    final height = track.height ?? 0;
-    final bitrate = track.bitrate ?? 0;
-    final mimeType = (track.mimeType ?? '').replaceAll('video/', '');
-    final trackName =
-        preferredName ??
-        '${width}x$height ${BetterPlayerUtils.formatBitrate(bitrate)} $mimeType';
-
-    final selectedTrack = betterPlayerController!.betterPlayerAsmsTrack;
-    final isSelected = selectedTrack != null && selectedTrack == track;
-
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        Navigator.of(context).pop();
-        betterPlayerController!.setTrack(track);
-      },
-      semanticsLabel: trackName,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        child: Row(
-          children: [
-            SizedBox(width: isSelected ? 8 : 16),
-            Visibility(
-              visible: isSelected,
-              child: Icon(
-                Icons.check_outlined,
-                color: betterPlayerControlsConfiguration.overflowModalTextColor,
-              ),
-            ),
-            const SizedBox(width: 16),
-            Text(
-              trackName,
-              style: _getOverflowMenuElementTextStyle(isSelected),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildResolutionSelectionRow(String name, String url) {
-    final isSelected =
-        url == betterPlayerController!.betterPlayerDataSource!.url;
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        Navigator.of(context).pop();
-        betterPlayerController!.setResolution(url);
-      },
-      semanticsLabel: name,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        child: Row(
-          children: [
-            SizedBox(width: isSelected ? 8 : 16),
-            Visibility(
-              visible: isSelected,
-              child: Icon(
-                Icons.check_outlined,
-                color: betterPlayerControlsConfiguration.overflowModalTextColor,
-              ),
-            ),
-            const SizedBox(width: 16),
-            Text(
-              name,
-              style: _getOverflowMenuElementTextStyle(isSelected),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 
   void _showAudioTracksSelectionWidget() {
@@ -420,66 +274,40 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
         final isSelected =
             selectedAsmsAudioTrack != null &&
             selectedAsmsAudioTrack == asmsTracks[index];
-        children.add(_buildAudioTrackRow(asmsTracks[index], isSelected));
+        final audioTrack = asmsTracks[index];
+        children.add(
+          BetterPlayerSelectionListItemWidget(
+            label: audioTrack.label!,
+            isSelected: isSelected,
+            onTap: () {
+              Navigator.of(context).pop();
+              betterPlayerController!.setAudioTrack(audioTrack);
+            },
+            controlsConfiguration: betterPlayerControlsConfiguration,
+          ),
+        );
       }
     }
 
     if (children.isEmpty) {
       children.add(
-        _buildAudioTrackRow(
-          BetterPlayerAsmsAudioTrack(
-            label: betterPlayerController!.translations.generalDefault,
-          ),
-          true,
+        BetterPlayerSelectionListItemWidget(
+          label: betterPlayerController!.translations.generalDefault,
+          isSelected: true,
+          onTap: () {
+            Navigator.of(context).pop();
+            betterPlayerController!.setAudioTrack(
+              BetterPlayerAsmsAudioTrack(
+                label: betterPlayerController!.translations.generalDefault,
+              ),
+            );
+          },
+          controlsConfiguration: betterPlayerControlsConfiguration,
         ),
       );
     }
 
     _showModalBottomSheet(children);
-  }
-
-  Widget _buildAudioTrackRow(
-    BetterPlayerAsmsAudioTrack audioTrack,
-    bool isSelected,
-  ) {
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        Navigator.of(context).pop();
-        betterPlayerController!.setAudioTrack(audioTrack);
-      },
-      semanticsLabel: audioTrack.label,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        child: Row(
-          children: [
-            SizedBox(width: isSelected ? 8 : 16),
-            Visibility(
-              visible: isSelected,
-              child: Icon(
-                Icons.check_outlined,
-                color: betterPlayerControlsConfiguration.overflowModalTextColor,
-              ),
-            ),
-            const SizedBox(width: 16),
-            Text(
-              audioTrack.label!,
-              style: _getOverflowMenuElementTextStyle(isSelected),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  TextStyle _getOverflowMenuElementTextStyle(bool isSelected) {
-    return TextStyle(
-      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-      color: isSelected
-          ? betterPlayerControlsConfiguration.overflowModalTextColor
-          : betterPlayerControlsConfiguration.overflowModalTextColor.withValues(
-              alpha: 0.7,
-            ),
-    );
   }
 
   void _showModalBottomSheet(List<Widget> children) {

--- a/lib/src/controls/better_player_cupertino_bottom_bar.dart
+++ b/lib/src/controls/better_player_cupertino_bottom_bar.dart
@@ -1,0 +1,346 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_cupertino_progress_bar.dart';
+import 'package:better_player/src/controls/better_player_progress_colors.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:better_player/src/core/better_player_utils.dart';
+import 'package:better_player/src/video_player/video_player.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerCupertinoBottomBar extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final double barHeight;
+  final double marginSize;
+  final Color backgroundColor;
+  final Color iconColor;
+  final VoidCallback onPlayPause;
+  final VoidCallback onSkipBack;
+  final VoidCallback onSkipForward;
+  final VoidCallback onProgressBarDragStart;
+  final VoidCallback onProgressBarDragEnd;
+  final VoidCallback onProgressBarTapDown;
+  final VoidCallback onPlayerHide;
+  final VideoPlayerValue? latestValue;
+
+  const BetterPlayerCupertinoBottomBar({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.barHeight,
+    required this.marginSize,
+    required this.backgroundColor,
+    required this.iconColor,
+    required this.onPlayPause,
+    required this.onSkipBack,
+    required this.onSkipForward,
+    required this.onProgressBarDragStart,
+    required this.onProgressBarDragEnd,
+    required this.onProgressBarTapDown,
+    required this.onPlayerHide,
+    required this.latestValue,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!controller.controlsEnabled) {
+      return const SizedBox();
+    }
+    return AnimatedOpacity(
+      opacity: controlsNotVisible ? 0.0 : 1.0,
+      duration: controlsConfiguration.controlsHideTime,
+      onEnd: onPlayerHide,
+      child: Container(
+        alignment: Alignment.bottomCenter,
+        margin: EdgeInsets.all(marginSize),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(10),
+          child: Container(
+            height: barHeight,
+            decoration: BoxDecoration(color: backgroundColor),
+            child: controller.isLiveStream()
+                ? Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      const SizedBox(width: 8),
+                      if (controlsConfiguration.enablePlayPause)
+                        _BetterPlayerCupertinoPlayPauseButton(
+                          controller: controller,
+                          controlsConfiguration: controlsConfiguration,
+                          onPlayPause: onPlayPause,
+                          iconColor: iconColor,
+                          barHeight: barHeight,
+                        )
+                      else
+                        const SizedBox(),
+                      const SizedBox(width: 8),
+                      _BetterPlayerCupertinoLiveWidget(
+                        controller: controller,
+                        controlsConfiguration: controlsConfiguration,
+                      ),
+                    ],
+                  )
+                : Row(
+                    children: <Widget>[
+                      if (controlsConfiguration.enableSkips)
+                        _BetterPlayerCupertinoSkipButton(
+                          controller: controller,
+                          onSkip: onSkipBack,
+                          icon: controlsConfiguration.skipBackIcon,
+                          semanticsLabel:
+                              controller.translations.controlsSkipBackwardLabel,
+                          iconColor: iconColor,
+                          barHeight: barHeight,
+                          isBack: true,
+                        )
+                      else
+                        const SizedBox(),
+                      if (controlsConfiguration.enablePlayPause)
+                        _BetterPlayerCupertinoPlayPauseButton(
+                          controller: controller,
+                          controlsConfiguration: controlsConfiguration,
+                          onPlayPause: onPlayPause,
+                          iconColor: iconColor,
+                          barHeight: barHeight,
+                        )
+                      else
+                        const SizedBox(),
+                      if (controlsConfiguration.enableSkips)
+                        _BetterPlayerCupertinoSkipButton(
+                          controller: controller,
+                          onSkip: onSkipForward,
+                          icon: controlsConfiguration.skipForwardIcon,
+                          semanticsLabel:
+                              controller.translations.controlsSkipForwardLabel,
+                          iconColor: iconColor,
+                          barHeight: barHeight,
+                          isBack: false,
+                        )
+                      else
+                        const SizedBox(),
+                      if (controlsConfiguration.enableProgressText)
+                        _BetterPlayerCupertinoPositionWidget(
+                          controlsConfiguration: controlsConfiguration,
+                          latestValue: latestValue,
+                        )
+                      else
+                        const SizedBox(),
+                      if (controlsConfiguration.enableProgressBar)
+                        _BetterPlayerCupertinoProgressBarWrapper(
+                          controller: controller,
+                          controlsConfiguration: controlsConfiguration,
+                          onDragStart: onProgressBarDragStart,
+                          onDragEnd: onProgressBarDragEnd,
+                          onTapDown: onProgressBarTapDown,
+                        )
+                      else
+                        const SizedBox(),
+                      if (controlsConfiguration.enableProgressText)
+                        _BetterPlayerCupertinoRemainingWidget(
+                          controlsConfiguration: controlsConfiguration,
+                          latestValue: latestValue,
+                        )
+                      else
+                        const SizedBox(),
+                    ],
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoPlayPauseButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onPlayPause;
+  final Color iconColor;
+  final double barHeight;
+
+  const _BetterPlayerCupertinoPlayPauseButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onPlayPause,
+    required this.iconColor,
+    required this.barHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isPlaying = controller.videoPlayerController!.value.isPlaying;
+    return GestureDetector(
+      onTap: onPlayPause,
+      child: Semantics(
+        label: isPlaying
+            ? controller.translations.controlsPauseLabel
+            : controller.translations.controlsPlayLabel,
+        button: true,
+        child: Container(
+          height: barHeight,
+          color: Colors.transparent,
+          padding: const EdgeInsets.symmetric(horizontal: 6),
+          child: Icon(
+            isPlaying
+                ? controlsConfiguration.pauseIcon
+                : controlsConfiguration.playIcon,
+            color: iconColor,
+            size: barHeight * 0.6,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoSkipButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final VoidCallback onSkip;
+  final IconData icon;
+  final String semanticsLabel;
+  final Color iconColor;
+  final double barHeight;
+  final bool isBack;
+
+  const _BetterPlayerCupertinoSkipButton({
+    required this.controller,
+    required this.onSkip,
+    required this.icon,
+    required this.semanticsLabel,
+    required this.iconColor,
+    required this.barHeight,
+    required this.isBack,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onSkip,
+      child: Semantics(
+        label: semanticsLabel,
+        button: true,
+        child: Container(
+          height: barHeight,
+          color: Colors.transparent,
+          margin: EdgeInsets.only(left: isBack ? 10 : 0, right: isBack ? 0 : 8),
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Icon(
+            icon,
+            color: iconColor,
+            size: barHeight * 0.4,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoLiveWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const _BetterPlayerCupertinoLiveWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Text(
+        controller.translations.controlsLive,
+        style: TextStyle(
+          color: controlsConfiguration.liveTextColor,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoPositionWidget extends StatelessWidget {
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VideoPlayerValue? latestValue;
+
+  const _BetterPlayerCupertinoPositionWidget({
+    required this.controlsConfiguration,
+    required this.latestValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final position = latestValue != null
+        ? latestValue!.position
+        : Duration.zero;
+    return Padding(
+      padding: const EdgeInsets.only(right: 12),
+      child: Text(
+        BetterPlayerUtils.formatDuration(position),
+        style: TextStyle(color: controlsConfiguration.textColor, fontSize: 12),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoRemainingWidget extends StatelessWidget {
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VideoPlayerValue? latestValue;
+
+  const _BetterPlayerCupertinoRemainingWidget({
+    required this.controlsConfiguration,
+    required this.latestValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final remaining = latestValue != null && latestValue!.duration != null
+        ? latestValue!.duration! - latestValue!.position
+        : Duration.zero;
+    return Padding(
+      padding: const EdgeInsets.only(right: 12),
+      child: Text(
+        '-${BetterPlayerUtils.formatDuration(remaining)}',
+        style: TextStyle(color: controlsConfiguration.textColor, fontSize: 12),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoProgressBarWrapper extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onDragStart;
+  final VoidCallback onDragEnd;
+  final VoidCallback onTapDown;
+
+  const _BetterPlayerCupertinoProgressBarWrapper({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onDragStart,
+    required this.onDragEnd,
+    required this.onTapDown,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.only(right: 12),
+        child: BetterPlayerCupertinoVideoProgressBar(
+          controller.videoPlayerController,
+          controller,
+          onDragStart: onDragStart,
+          onDragEnd: onDragEnd,
+          onTapDown: onTapDown,
+          colors: BetterPlayerProgressColors(
+            playedColor: controlsConfiguration.progressBarPlayedColor,
+            handleColor: controlsConfiguration.progressBarHandleColor,
+            bufferedColor: controlsConfiguration.progressBarBufferedColor,
+            backgroundColor: controlsConfiguration.progressBarBackgroundColor,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_cupertino_bottom_bar.dart
+++ b/lib/src/controls/better_player_cupertino_bottom_bar.dart
@@ -71,6 +71,7 @@ class BetterPlayerCupertinoBottomBar extends StatelessWidget {
                           onPlayPause: onPlayPause,
                           iconColor: iconColor,
                           barHeight: barHeight,
+                          latestValue: latestValue,
                         )
                       else
                         const SizedBox(),
@@ -103,6 +104,7 @@ class BetterPlayerCupertinoBottomBar extends StatelessWidget {
                           onPlayPause: onPlayPause,
                           iconColor: iconColor,
                           barHeight: barHeight,
+                          latestValue: latestValue,
                         )
                       else
                         const SizedBox(),
@@ -158,6 +160,7 @@ class _BetterPlayerCupertinoPlayPauseButton extends StatelessWidget {
   final VoidCallback onPlayPause;
   final Color iconColor;
   final double barHeight;
+  final VideoPlayerValue? latestValue;
 
   const _BetterPlayerCupertinoPlayPauseButton({
     required this.controller,
@@ -165,11 +168,12 @@ class _BetterPlayerCupertinoPlayPauseButton extends StatelessWidget {
     required this.onPlayPause,
     required this.iconColor,
     required this.barHeight,
+    required this.latestValue,
   });
 
   @override
   Widget build(BuildContext context) {
-    final isPlaying = controller.videoPlayerController!.value.isPlaying;
+    final isPlaying = latestValue?.isPlaying ?? false;
     return GestureDetector(
       onTap: onPlayPause,
       child: Semantics(

--- a/lib/src/controls/better_player_cupertino_bottom_bar.dart
+++ b/lib/src/controls/better_player_cupertino_bottom_bar.dart
@@ -228,7 +228,7 @@ class _BetterPlayerCupertinoSkipButton extends StatelessWidget {
           height: barHeight,
           color: Colors.transparent,
           margin: EdgeInsets.only(left: isBack ? 10 : 0, right: isBack ? 0 : 8),
-          padding: const EdgeInsets.symmetric(horizontal: 8),
+          padding: EdgeInsets.symmetric(horizontal: isBack ? 8 : 6),
           child: Icon(
             icon,
             color: iconColor,

--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -1,13 +1,17 @@
 import 'dart:async';
+
 import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
 import 'package:better_player/src/controls/better_player_controls_state.dart';
-import 'package:better_player/src/controls/better_player_cupertino_progress_bar.dart';
+import 'package:better_player/src/controls/better_player_cupertino_bottom_bar.dart';
+import 'package:better_player/src/controls/better_player_cupertino_error_widget.dart';
+import 'package:better_player/src/controls/better_player_cupertino_hit_area.dart';
+import 'package:better_player/src/controls/better_player_cupertino_loading_widget.dart';
+import 'package:better_player/src/controls/better_player_cupertino_next_video_widget.dart';
+import 'package:better_player/src/controls/better_player_cupertino_top_bar.dart';
 import 'package:better_player/src/controls/better_player_multiple_gesture_detector.dart';
-import 'package:better_player/src/controls/better_player_progress_colors.dart';
 import 'package:better_player/src/core/better_player_controller.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/video_player/video_player.dart';
-import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerCupertinoControls extends StatefulWidget {
@@ -68,7 +72,10 @@ class _BetterPlayerCupertinoControlsState
     if (_latestValue?.hasError == true) {
       return ColoredBox(
         color: Colors.black,
-        child: _buildErrorWidget(),
+        child: BetterPlayerCupertinoErrorWidget(
+          controller: _betterPlayerController!,
+          controlsConfiguration: _controlsConfiguration,
+        ),
       );
     }
 
@@ -86,21 +93,57 @@ class _BetterPlayerCupertinoControlsState
     _wasLoading = isLoading(_latestValue);
     final controlsColumn = Column(
       children: <Widget>[
-        _buildTopBar(
-          backgroundColor,
-          iconColor,
-          barHeight,
-          buttonPadding,
+        BetterPlayerCupertinoTopBar(
+          controller: _betterPlayerController!,
+          controlsConfiguration: _controlsConfiguration,
+          controlsNotVisible: controlsNotVisible,
+          barHeight: barHeight * 0.8,
+          iconSize: barHeight * 0.4,
+          buttonPadding: buttonPadding,
+          marginSize: marginSize,
+          backgroundColor: backgroundColor,
+          iconColor: iconColor,
+          onExpandCollapse: _onExpandCollapse,
+          onShowMoreClicked: onShowMoreClicked,
+          onMute: _onMute,
+          latestValue: _latestValue,
         ),
         if (_wasLoading)
-          Expanded(child: Center(child: _buildLoadingWidget()))
+          Expanded(
+            child: Center(
+              child: BetterPlayerCupertinoLoadingWidget(
+                controlsConfiguration: _controlsConfiguration,
+              ),
+            ),
+          )
         else
-          _buildHitArea(),
-        _buildNextVideoWidget(),
-        _buildBottomBar(
-          backgroundColor,
-          iconColor,
-          barHeight,
+          BetterPlayerCupertinoHitArea(
+            latestValue: _latestValue,
+            controlsNotVisible: controlsNotVisible,
+            onCancelAndRestartTimer: cancelAndRestartTimer,
+            onHideTimerCancel: () => _hideTimer?.cancel(),
+            onChangePlayerControlsNotVisible: changePlayerControlsNotVisible,
+          ),
+        BetterPlayerCupertinoNextVideoWidget(
+          controller: _betterPlayerController!,
+          controlsConfiguration: _controlsConfiguration,
+        ),
+        BetterPlayerCupertinoBottomBar(
+          controller: _betterPlayerController!,
+          controlsConfiguration: _controlsConfiguration,
+          controlsNotVisible: controlsNotVisible,
+          barHeight: barHeight,
+          marginSize: marginSize,
+          backgroundColor: backgroundColor,
+          iconColor: iconColor,
+          onPlayPause: _onPlayPause,
+          onSkipBack: skipBack,
+          onSkipForward: skipForward,
+          onProgressBarDragStart: () => _hideTimer?.cancel(),
+          onProgressBarDragEnd: _startHideTimer,
+          onProgressBarTapDown: cancelAndRestartTimer,
+          onPlayerHide: _onPlayerHide,
+          latestValue: _latestValue,
         ),
       ],
     );
@@ -160,472 +203,20 @@ class _BetterPlayerCupertinoControlsState
     super.didChangeDependencies();
   }
 
-  Widget _buildBottomBar(
-    Color backgroundColor,
-    Color iconColor,
-    double barHeight,
-  ) {
-    if (!betterPlayerController!.controlsEnabled) {
-      return const SizedBox();
+  void _onMute() {
+    cancelAndRestartTimer();
+
+    if (_latestValue!.volume == 0) {
+      _controller!.setVolume(_latestVolume ?? 0.5);
+    } else {
+      _latestVolume = _controller!.value.volume;
+      _controller!.setVolume(0);
     }
-    return AnimatedOpacity(
-      opacity: controlsNotVisible ? 0.0 : 1.0,
-      duration: _controlsConfiguration.controlsHideTime,
-      onEnd: _onPlayerHide,
-      child: Container(
-        alignment: Alignment.bottomCenter,
-        margin: EdgeInsets.all(marginSize),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(10),
-          child: Container(
-            height: barHeight,
-            decoration: BoxDecoration(
-              color: backgroundColor,
-            ),
-            child: _betterPlayerController!.isLiveStream()
-                ? Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      const SizedBox(width: 8),
-                      if (_controlsConfiguration.enablePlayPause)
-                        _buildPlayPause(_controller!, iconColor, barHeight)
-                      else
-                        const SizedBox(),
-                      const SizedBox(width: 8),
-                      _buildLiveWidget(),
-                    ],
-                  )
-                : Row(
-                    children: <Widget>[
-                      if (_controlsConfiguration.enableSkips)
-                        _buildSkipBack(iconColor, barHeight)
-                      else
-                        const SizedBox(),
-                      if (_controlsConfiguration.enablePlayPause)
-                        _buildPlayPause(_controller!, iconColor, barHeight)
-                      else
-                        const SizedBox(),
-                      if (_controlsConfiguration.enableSkips)
-                        _buildSkipForward(iconColor, barHeight)
-                      else
-                        const SizedBox(),
-                      if (_controlsConfiguration.enableProgressText)
-                        _buildPosition()
-                      else
-                        const SizedBox(),
-                      if (_controlsConfiguration.enableProgressBar)
-                        _buildProgressBar()
-                      else
-                        const SizedBox(),
-                      if (_controlsConfiguration.enableProgressText)
-                        _buildRemaining()
-                      else
-                        const SizedBox(),
-                    ],
-                  ),
-          ),
-        ),
-      ),
-    );
   }
 
-  Widget _buildLiveWidget() {
-    return Expanded(
-      child: Text(
-        _betterPlayerController!.translations.controlsLive,
-        style: TextStyle(
-          color: _controlsConfiguration.liveTextColor,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-    );
-  }
-
-  GestureDetector _buildExpandButton(
-    Color backgroundColor,
-    Color iconColor,
-    double barHeight,
-    double iconSize,
-    double buttonPadding,
-  ) {
-    return GestureDetector(
-      onTap: _onExpandCollapse,
-      child: Semantics(
-        label: _betterPlayerController!.isFullScreen
-            ? _betterPlayerController!.translations.controlsExitFullscreenLabel
-            : _betterPlayerController!.translations.controlsFullscreenLabel,
-        button: true,
-        onTap: _onExpandCollapse,
-        child: AnimatedOpacity(
-          opacity: controlsNotVisible ? 0.0 : 1.0,
-          duration: _controlsConfiguration.controlsHideTime,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: Container(
-              height: barHeight,
-              padding: EdgeInsets.symmetric(
-                horizontal: buttonPadding,
-              ),
-              decoration: BoxDecoration(color: backgroundColor),
-              child: Center(
-                child: Icon(
-                  _betterPlayerController!.isFullScreen
-                      ? _controlsConfiguration.fullscreenDisableIcon
-                      : _controlsConfiguration.fullscreenEnableIcon,
-                  color: iconColor,
-                  size: iconSize,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Expanded _buildHitArea() {
-    return Expanded(
-      child: GestureDetector(
-        onTap: _latestValue != null && _latestValue!.isPlaying
-            ? () {
-                if (controlsNotVisible == true) {
-                  cancelAndRestartTimer();
-                } else {
-                  _hideTimer?.cancel();
-                  changePlayerControlsNotVisible(true);
-                }
-              }
-            : () {
-                _hideTimer?.cancel();
-                changePlayerControlsNotVisible(false);
-              },
-        child: Container(
-          color: Colors.transparent,
-        ),
-      ),
-    );
-  }
-
-  GestureDetector _buildMoreButton(
-    VideoPlayerController? controller,
-    Color backgroundColor,
-    Color iconColor,
-    double barHeight,
-    double iconSize,
-    double buttonPadding,
-  ) {
-    return GestureDetector(
-      onTap: onShowMoreClicked,
-      child: Semantics(
-        label: _betterPlayerController!.translations.overflowMenuLabel,
-        button: true,
-        onTap: onShowMoreClicked,
-        child: AnimatedOpacity(
-          opacity: controlsNotVisible ? 0.0 : 1.0,
-          duration: _controlsConfiguration.controlsHideTime,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: Container(
-              decoration: BoxDecoration(
-                color: backgroundColor,
-              ),
-              child: Container(
-                height: barHeight,
-                padding: EdgeInsets.symmetric(
-                  horizontal: buttonPadding,
-                ),
-                child: Icon(
-                  _controlsConfiguration.overflowMenuIcon,
-                  color: iconColor,
-                  size: iconSize,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  GestureDetector _buildMuteButton(
-    VideoPlayerController? controller,
-    Color backgroundColor,
-    Color iconColor,
-    double barHeight,
-    double iconSize,
-    double buttonPadding,
-  ) {
-    final isMuted = _latestValue != null && _latestValue!.volume == 0;
-    final semanticsLabel = isMuted
-        ? _betterPlayerController!.translations.controlsUnmuteLabel
-        : _betterPlayerController!.translations.controlsMuteLabel;
-
-    return GestureDetector(
-      onTap: () {
-        cancelAndRestartTimer();
-
-        if (_latestValue!.volume == 0) {
-          controller!.setVolume(_latestVolume ?? 0.5);
-        } else {
-          _latestVolume = controller!.value.volume;
-          controller.setVolume(0);
-        }
-      },
-      child: Semantics(
-        label: semanticsLabel,
-        button: true,
-        onTap: () {
-          cancelAndRestartTimer();
-
-          if (_latestValue!.volume == 0) {
-            controller!.setVolume(_latestVolume ?? 0.5);
-          } else {
-            _latestVolume = controller!.value.volume;
-            controller.setVolume(0);
-          }
-        },
-        child: AnimatedOpacity(
-          opacity: controlsNotVisible ? 0.0 : 1.0,
-          duration: _controlsConfiguration.controlsHideTime,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: Container(
-              decoration: BoxDecoration(
-                color: backgroundColor,
-              ),
-              child: Container(
-                height: barHeight,
-                padding: EdgeInsets.symmetric(
-                  horizontal: buttonPadding,
-                ),
-                child: Icon(
-                  (_latestValue != null && _latestValue!.volume > 0)
-                      ? _controlsConfiguration.muteIcon
-                      : _controlsConfiguration.unMuteIcon,
-                  color: iconColor,
-                  size: iconSize,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  GestureDetector _buildPlayPause(
-    VideoPlayerController controller,
-    Color iconColor,
-    double barHeight,
-  ) {
-    return GestureDetector(
-      onTap: _onPlayPause,
-      child: Semantics(
-        label: controller.value.isPlaying
-            ? _betterPlayerController!.translations.controlsPauseLabel
-            : _betterPlayerController!.translations.controlsPlayLabel,
-        button: true,
-        onTap: _onPlayPause,
-        child: Container(
-          height: barHeight,
-          color: Colors.transparent,
-          padding: const EdgeInsets.symmetric(horizontal: 6),
-          child: Icon(
-            controller.value.isPlaying
-                ? _controlsConfiguration.pauseIcon
-                : _controlsConfiguration.playIcon,
-            color: iconColor,
-            size: barHeight * 0.6,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPosition() {
-    final position = _latestValue != null
-        ? _latestValue!.position
-        : const Duration();
-
-    return Padding(
-      padding: const EdgeInsets.only(right: 12),
-      child: Text(
-        BetterPlayerUtils.formatDuration(position),
-        style: TextStyle(
-          color: _controlsConfiguration.textColor,
-          fontSize: 12,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildRemaining() {
-    final position = _latestValue != null && _latestValue!.duration != null
-        ? _latestValue!.duration! - _latestValue!.position
-        : const Duration();
-
-    return Padding(
-      padding: const EdgeInsets.only(right: 12),
-      child: Text(
-        '-${BetterPlayerUtils.formatDuration(position)}',
-        style: TextStyle(color: _controlsConfiguration.textColor, fontSize: 12),
-      ),
-    );
-  }
-
-  GestureDetector _buildSkipBack(Color iconColor, double barHeight) {
-    return GestureDetector(
-      onTap: skipBack,
-      child: Semantics(
-        label: _betterPlayerController!.translations.controlsSkipBackwardLabel,
-        button: true,
-        onTap: skipBack,
-        child: Container(
-          height: barHeight,
-          color: Colors.transparent,
-          margin: const EdgeInsets.only(left: 10),
-          padding: const EdgeInsets.symmetric(
-            horizontal: 8,
-          ),
-          child: Icon(
-            _controlsConfiguration.skipBackIcon,
-            color: iconColor,
-            size: barHeight * 0.4,
-          ),
-        ),
-      ),
-    );
-  }
-
-  GestureDetector _buildSkipForward(Color iconColor, double barHeight) {
-    return GestureDetector(
-      onTap: skipForward,
-      child: Semantics(
-        label: _betterPlayerController!.translations.controlsSkipForwardLabel,
-        button: true,
-        onTap: skipForward,
-        child: Container(
-          height: barHeight,
-          color: Colors.transparent,
-          padding: const EdgeInsets.symmetric(horizontal: 6),
-          margin: const EdgeInsets.only(right: 8),
-          child: Icon(
-            _controlsConfiguration.skipForwardIcon,
-            color: iconColor,
-            size: barHeight * 0.4,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildTopBar(
-    Color backgroundColor,
-    Color iconColor,
-    double topBarHeight,
-    double buttonPadding,
-  ) {
-    if (!betterPlayerController!.controlsEnabled) {
-      return const SizedBox();
-    }
-    final barHeight = topBarHeight * 0.8;
-    final iconSize = topBarHeight * 0.4;
-    return Container(
-      height: barHeight,
-      margin: EdgeInsets.only(
-        top: marginSize,
-        right: marginSize,
-        left: marginSize,
-      ),
-      child: Row(
-        children: <Widget>[
-          if (_controlsConfiguration.enableFullscreen)
-            _buildExpandButton(
-              backgroundColor,
-              iconColor,
-              barHeight,
-              iconSize,
-              buttonPadding,
-            )
-          else
-            const SizedBox(),
-          const SizedBox(
-            width: 4,
-          ),
-          if (_controlsConfiguration.enablePip)
-            _buildPipButton(
-              backgroundColor,
-              iconColor,
-              barHeight,
-              iconSize,
-              buttonPadding,
-            )
-          else
-            const SizedBox(),
-          const Spacer(),
-          if (_controlsConfiguration.enableMute)
-            _buildMuteButton(
-              _controller,
-              backgroundColor,
-              iconColor,
-              barHeight,
-              iconSize,
-              buttonPadding,
-            )
-          else
-            const SizedBox(),
-          const SizedBox(
-            width: 4,
-          ),
-          if (_controlsConfiguration.enableOverflowMenu)
-            _buildMoreButton(
-              _controller,
-              backgroundColor,
-              iconColor,
-              barHeight,
-              iconSize,
-              buttonPadding,
-            )
-          else
-            const SizedBox(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildNextVideoWidget() {
-    return StreamBuilder<int?>(
-      stream: _betterPlayerController!.nextVideoTimeStream,
-      builder: (context, snapshot) {
-        final time = snapshot.data;
-        if (time != null && time > 0) {
-          return InkWell(
-            onTap: () {
-              _betterPlayerController!.playNextVideo();
-            },
-            child: Align(
-              alignment: Alignment.bottomRight,
-              child: Container(
-                margin: const EdgeInsets.only(bottom: 4, right: 8),
-                decoration: BoxDecoration(
-                  color: _controlsConfiguration.controlBarColor,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Text(
-                    '${_betterPlayerController!.translations.controlsNextVideoIn} $time ...',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                ),
-              ),
-            ),
-          );
-        } else {
-          return const SizedBox();
-        }
-      },
-    );
+  void _onPlayerHide() {
+    _betterPlayerController!.toggleControlsVisibility(!controlsNotVisible);
+    widget.onControlsVisibilityChanged(!controlsNotVisible);
   }
 
   @override
@@ -667,33 +258,6 @@ class _BetterPlayerCupertinoControlsState
     _expandCollapseTimer = Timer(_controlsConfiguration.controlsHideTime, () {
       setState(cancelAndRestartTimer);
     });
-  }
-
-  Widget _buildProgressBar() {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.only(right: 12),
-        child: BetterPlayerCupertinoVideoProgressBar(
-          _controller,
-          _betterPlayerController,
-          onDragStart: () {
-            _hideTimer?.cancel();
-          },
-          onDragEnd: () {
-            _startHideTimer();
-          },
-          onTapDown: () {
-            cancelAndRestartTimer();
-          },
-          colors: BetterPlayerProgressColors(
-            playedColor: _controlsConfiguration.progressBarPlayedColor,
-            handleColor: _controlsConfiguration.progressBarHandleColor,
-            bufferedColor: _controlsConfiguration.progressBarBufferedColor,
-            backgroundColor: _controlsConfiguration.progressBarBackgroundColor,
-          ),
-        ),
-      ),
-    );
   }
 
   void _onPlayPause() {
@@ -749,121 +313,5 @@ class _BetterPlayerCupertinoControlsState
         });
       }
     }
-  }
-
-  void _onPlayerHide() {
-    _betterPlayerController!.toggleControlsVisibility(!controlsNotVisible);
-    widget.onControlsVisibilityChanged(!controlsNotVisible);
-  }
-
-  Widget _buildErrorWidget() {
-    final errorBuilder =
-        _betterPlayerController!.betterPlayerConfiguration.errorBuilder;
-    if (errorBuilder != null) {
-      return errorBuilder(
-        context,
-        _betterPlayerController!.videoPlayerController!.value.errorDescription,
-      );
-    } else {
-      final textStyle = TextStyle(color: _controlsConfiguration.textColor);
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              CupertinoIcons.exclamationmark_triangle,
-              color: _controlsConfiguration.iconsColor,
-              size: 42,
-            ),
-            Text(
-              _betterPlayerController!.translations.generalDefaultError,
-              style: textStyle,
-            ),
-            if (_controlsConfiguration.enableRetry)
-              TextButton(
-                onPressed: () {
-                  _betterPlayerController!.retryDataSource();
-                },
-                child: Text(
-                  _betterPlayerController!.translations.generalRetry,
-                  style: textStyle.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
-          ],
-        ),
-      );
-    }
-  }
-
-  Widget? _buildLoadingWidget() {
-    if (_controlsConfiguration.loadingWidget != null) {
-      return _controlsConfiguration.loadingWidget;
-    }
-
-    return CircularProgressIndicator(
-      valueColor: AlwaysStoppedAnimation<Color>(
-        _controlsConfiguration.loadingColor,
-      ),
-    );
-  }
-
-  Widget _buildPipButton(
-    Color backgroundColor,
-    Color iconColor,
-    double barHeight,
-    double iconSize,
-    double buttonPadding,
-  ) {
-    return FutureBuilder<bool>(
-      future: _betterPlayerController!.isPictureInPictureSupported(),
-      builder: (context, snapshot) {
-        final isPipSupported = snapshot.data ?? false;
-        if (isPipSupported &&
-            _betterPlayerController!.betterPlayerGlobalKey != null) {
-          return GestureDetector(
-            onTap: () {
-              betterPlayerController!.enablePictureInPicture(
-                betterPlayerController!.betterPlayerGlobalKey!,
-              );
-            },
-            child: Semantics(
-              label: _betterPlayerController!.translations.controlsPipLabel,
-              button: true,
-              onTap: () {
-                betterPlayerController!.enablePictureInPicture(
-                  betterPlayerController!.betterPlayerGlobalKey!,
-                );
-              },
-              child: AnimatedOpacity(
-                opacity: controlsNotVisible ? 0.0 : 1.0,
-                duration: _controlsConfiguration.controlsHideTime,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(10),
-                  child: Container(
-                    height: barHeight,
-                    padding: EdgeInsets.only(
-                      left: buttonPadding,
-                      right: buttonPadding,
-                    ),
-                    decoration: BoxDecoration(
-                      color: backgroundColor.withValues(alpha: 0.5),
-                    ),
-                    child: Center(
-                      child: Icon(
-                        _controlsConfiguration.pipMenuIcon,
-                        color: iconColor,
-                        size: iconSize,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          );
-        } else {
-          return const SizedBox();
-        }
-      },
-    );
   }
 }

--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -205,6 +205,9 @@ class _BetterPlayerCupertinoControlsState
 
   void _onMute() {
     cancelAndRestartTimer();
+    if (_latestValue == null) {
+      return;
+    }
 
     if (_latestValue!.volume == 0) {
       _controller!.setVolume(_latestVolume ?? 0.5);

--- a/lib/src/controls/better_player_cupertino_error_widget.dart
+++ b/lib/src/controls/better_player_cupertino_error_widget.dart
@@ -1,0 +1,52 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerCupertinoErrorWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerCupertinoErrorWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final errorBuilder = controller.betterPlayerConfiguration.errorBuilder;
+    if (errorBuilder != null) {
+      return errorBuilder(
+        context,
+        controller.videoPlayerController!.value.errorDescription,
+      );
+    } else {
+      final textStyle = TextStyle(color: controlsConfiguration.textColor);
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              CupertinoIcons.exclamationmark_triangle,
+              color: controlsConfiguration.iconsColor,
+              size: 42,
+            ),
+            Text(
+              controller.translations.generalDefaultError,
+              style: textStyle,
+            ),
+            if (controlsConfiguration.enableRetry)
+              TextButton(
+                onPressed: controller.retryDataSource,
+                child: Text(
+                  controller.translations.generalRetry,
+                  style: textStyle.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+  }
+}

--- a/lib/src/controls/better_player_cupertino_hit_area.dart
+++ b/lib/src/controls/better_player_cupertino_hit_area.dart
@@ -1,0 +1,43 @@
+import 'package:better_player/src/video_player/video_player.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerCupertinoHitArea extends StatelessWidget {
+  final VideoPlayerValue? latestValue;
+  final bool controlsNotVisible;
+  final VoidCallback onCancelAndRestartTimer;
+  final VoidCallback onHideTimerCancel;
+  final Function(bool) onChangePlayerControlsNotVisible;
+
+  const BetterPlayerCupertinoHitArea({
+    required this.latestValue,
+    required this.controlsNotVisible,
+    required this.onCancelAndRestartTimer,
+    required this.onHideTimerCancel,
+    required this.onChangePlayerControlsNotVisible,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: latestValue != null && latestValue!.isPlaying
+            ? () {
+                if (controlsNotVisible) {
+                  onCancelAndRestartTimer();
+                } else {
+                  onHideTimerCancel();
+                  onChangePlayerControlsNotVisible(true);
+                }
+              }
+            : () {
+                onHideTimerCancel();
+                onChangePlayerControlsNotVisible(false);
+              },
+        child: Container(
+          color: Colors.transparent,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_cupertino_loading_widget.dart
+++ b/lib/src/controls/better_player_cupertino_loading_widget.dart
@@ -1,0 +1,24 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerCupertinoLoadingWidget extends StatelessWidget {
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerCupertinoLoadingWidget({
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (controlsConfiguration.loadingWidget != null) {
+      return controlsConfiguration.loadingWidget!;
+    }
+
+    return CircularProgressIndicator(
+      valueColor: AlwaysStoppedAnimation<Color>(
+        controlsConfiguration.loadingColor,
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_cupertino_next_video_widget.dart
+++ b/lib/src/controls/better_player_cupertino_next_video_widget.dart
@@ -1,0 +1,48 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerCupertinoNextVideoWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerCupertinoNextVideoWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<int?>(
+      stream: controller.nextVideoTimeStream,
+      builder: (context, snapshot) {
+        final time = snapshot.data;
+        if (time != null && time > 0) {
+          return InkWell(
+            onTap: controller.playNextVideo,
+            child: Align(
+              alignment: Alignment.bottomRight,
+              child: Container(
+                margin: const EdgeInsets.only(bottom: 4, right: 8),
+                decoration: BoxDecoration(
+                  color: controlsConfiguration.controlBarColor,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text(
+                    '${controller.translations.controlsNextVideoIn} $time ...',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+              ),
+            ),
+          );
+        } else {
+          return const SizedBox();
+        }
+      },
+    );
+  }
+}

--- a/lib/src/controls/better_player_cupertino_top_bar.dart
+++ b/lib/src/controls/better_player_cupertino_top_bar.dart
@@ -174,7 +174,7 @@ class _BetterPlayerCupertinoExpandButton extends StatelessWidget {
   }
 }
 
-class _BetterPlayerCupertinoPipButton extends StatelessWidget {
+class _BetterPlayerCupertinoPipButton extends StatefulWidget {
   final BetterPlayerController controller;
   final BetterPlayerControlsConfiguration controlsConfiguration;
   final bool controlsNotVisible;
@@ -196,35 +196,60 @@ class _BetterPlayerCupertinoPipButton extends StatelessWidget {
   });
 
   @override
+  State<_BetterPlayerCupertinoPipButton> createState() =>
+      _BetterPlayerCupertinoPipButtonState();
+}
+
+class _BetterPlayerCupertinoPipButtonState
+    extends State<_BetterPlayerCupertinoPipButton> {
+  late Future<bool> _isPipSupportedFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _isPipSupportedFuture = widget.controller.isPictureInPictureSupported();
+  }
+
+  @override
+  void didUpdateWidget(covariant _BetterPlayerCupertinoPipButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      _isPipSupportedFuture = widget.controller.isPictureInPictureSupported();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return FutureBuilder<bool>(
-      future: controller.isPictureInPictureSupported(),
+      future: _isPipSupportedFuture,
       builder: (context, snapshot) {
         final isPipSupported = snapshot.data ?? false;
-        if (isPipSupported && controller.betterPlayerGlobalKey != null) {
+        if (isPipSupported && widget.controller.betterPlayerGlobalKey != null) {
           return GestureDetector(
-            onTap: () => controller.enablePictureInPicture(
-              controller.betterPlayerGlobalKey!,
+            onTap: () => widget.controller.enablePictureInPicture(
+              widget.controller.betterPlayerGlobalKey!,
             ),
             child: Semantics(
-              label: controller.translations.controlsPipLabel,
+              label: widget.controller.translations.controlsPipLabel,
               button: true,
               child: AnimatedOpacity(
-                opacity: controlsNotVisible ? 0.0 : 1.0,
-                duration: controlsConfiguration.controlsHideTime,
+                opacity: widget.controlsNotVisible ? 0.0 : 1.0,
+                duration: widget.controlsConfiguration.controlsHideTime,
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(10),
                   child: Container(
-                    height: barHeight,
-                    padding: EdgeInsets.symmetric(horizontal: buttonPadding),
+                    height: widget.barHeight,
+                    padding: EdgeInsets.symmetric(
+                      horizontal: widget.buttonPadding,
+                    ),
                     decoration: BoxDecoration(
-                      color: backgroundColor.withValues(alpha: 0.5),
+                      color: widget.backgroundColor.withValues(alpha: 0.5),
                     ),
                     child: Center(
                       child: Icon(
-                        controlsConfiguration.pipMenuIcon,
-                        color: iconColor,
-                        size: iconSize,
+                        widget.controlsConfiguration.pipMenuIcon,
+                        color: widget.iconColor,
+                        size: widget.iconSize,
                       ),
                     ),
                   ),

--- a/lib/src/controls/better_player_cupertino_top_bar.dart
+++ b/lib/src/controls/better_player_cupertino_top_bar.dart
@@ -1,0 +1,358 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:better_player/src/video_player/video_player.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerCupertinoTopBar extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final double barHeight;
+  final double iconSize;
+  final double buttonPadding;
+  final double marginSize;
+  final Color backgroundColor;
+  final Color iconColor;
+  final VoidCallback onExpandCollapse;
+  final VoidCallback onShowMoreClicked;
+  final VoidCallback onMute;
+  final VideoPlayerValue? latestValue;
+
+  const BetterPlayerCupertinoTopBar({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.barHeight,
+    required this.iconSize,
+    required this.buttonPadding,
+    required this.marginSize,
+    required this.backgroundColor,
+    required this.iconColor,
+    required this.onExpandCollapse,
+    required this.onShowMoreClicked,
+    required this.onMute,
+    required this.latestValue,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!controller.controlsEnabled) {
+      return const SizedBox();
+    }
+
+    return Container(
+      height: barHeight,
+      margin: EdgeInsets.only(
+        top: marginSize,
+        right: marginSize,
+        left: marginSize,
+      ),
+      child: Row(
+        children: <Widget>[
+          if (controlsConfiguration.enableFullscreen)
+            _BetterPlayerCupertinoExpandButton(
+              controller: controller,
+              controlsConfiguration: controlsConfiguration,
+              controlsNotVisible: controlsNotVisible,
+              barHeight: barHeight,
+              iconSize: iconSize,
+              buttonPadding: buttonPadding,
+              backgroundColor: backgroundColor,
+              iconColor: iconColor,
+              onExpandCollapse: onExpandCollapse,
+            )
+          else
+            const SizedBox(),
+          const SizedBox(width: 4),
+          if (controlsConfiguration.enablePip)
+            _BetterPlayerCupertinoPipButton(
+              controller: controller,
+              controlsConfiguration: controlsConfiguration,
+              controlsNotVisible: controlsNotVisible,
+              barHeight: barHeight,
+              iconSize: iconSize,
+              buttonPadding: buttonPadding,
+              backgroundColor: backgroundColor,
+              iconColor: iconColor,
+            )
+          else
+            const SizedBox(),
+          const Spacer(),
+          if (controlsConfiguration.enableMute)
+            _BetterPlayerCupertinoMuteButton(
+              controller: controller,
+              controlsConfiguration: controlsConfiguration,
+              controlsNotVisible: controlsNotVisible,
+              barHeight: barHeight,
+              iconSize: iconSize,
+              buttonPadding: buttonPadding,
+              backgroundColor: backgroundColor,
+              iconColor: iconColor,
+              onMute: onMute,
+              latestValue: latestValue,
+            )
+          else
+            const SizedBox(),
+          const SizedBox(width: 4),
+          if (controlsConfiguration.enableOverflowMenu)
+            _BetterPlayerCupertinoMoreButton(
+              controller: controller,
+              controlsConfiguration: controlsConfiguration,
+              controlsNotVisible: controlsNotVisible,
+              barHeight: barHeight,
+              iconSize: iconSize,
+              buttonPadding: buttonPadding,
+              backgroundColor: backgroundColor,
+              iconColor: iconColor,
+              onShowMoreClicked: onShowMoreClicked,
+            )
+          else
+            const SizedBox(),
+        ],
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoExpandButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final double barHeight;
+  final double iconSize;
+  final double buttonPadding;
+  final Color backgroundColor;
+  final Color iconColor;
+  final VoidCallback onExpandCollapse;
+
+  const _BetterPlayerCupertinoExpandButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.barHeight,
+    required this.iconSize,
+    required this.buttonPadding,
+    required this.backgroundColor,
+    required this.iconColor,
+    required this.onExpandCollapse,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onExpandCollapse,
+      child: Semantics(
+        label: controller.isFullScreen
+            ? controller.translations.controlsExitFullscreenLabel
+            : controller.translations.controlsFullscreenLabel,
+        button: true,
+        child: AnimatedOpacity(
+          opacity: controlsNotVisible ? 0.0 : 1.0,
+          duration: controlsConfiguration.controlsHideTime,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: Container(
+              height: barHeight,
+              padding: EdgeInsets.symmetric(horizontal: buttonPadding),
+              decoration: BoxDecoration(color: backgroundColor),
+              child: Center(
+                child: Icon(
+                  controller.isFullScreen
+                      ? controlsConfiguration.fullscreenDisableIcon
+                      : controlsConfiguration.fullscreenEnableIcon,
+                  color: iconColor,
+                  size: iconSize,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoPipButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final double barHeight;
+  final double iconSize;
+  final double buttonPadding;
+  final Color backgroundColor;
+  final Color iconColor;
+
+  const _BetterPlayerCupertinoPipButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.barHeight,
+    required this.iconSize,
+    required this.buttonPadding,
+    required this.backgroundColor,
+    required this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: controller.isPictureInPictureSupported(),
+      builder: (context, snapshot) {
+        final isPipSupported = snapshot.data ?? false;
+        if (isPipSupported && controller.betterPlayerGlobalKey != null) {
+          return GestureDetector(
+            onTap: () => controller.enablePictureInPicture(
+              controller.betterPlayerGlobalKey!,
+            ),
+            child: Semantics(
+              label: controller.translations.controlsPipLabel,
+              button: true,
+              child: AnimatedOpacity(
+                opacity: controlsNotVisible ? 0.0 : 1.0,
+                duration: controlsConfiguration.controlsHideTime,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(10),
+                  child: Container(
+                    height: barHeight,
+                    padding: EdgeInsets.symmetric(horizontal: buttonPadding),
+                    decoration: BoxDecoration(
+                      color: backgroundColor.withValues(alpha: 0.5),
+                    ),
+                    child: Center(
+                      child: Icon(
+                        controlsConfiguration.pipMenuIcon,
+                        color: iconColor,
+                        size: iconSize,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        } else {
+          return const SizedBox();
+        }
+      },
+    );
+  }
+}
+
+class _BetterPlayerCupertinoMuteButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final double barHeight;
+  final double iconSize;
+  final double buttonPadding;
+  final Color backgroundColor;
+  final Color iconColor;
+  final VoidCallback onMute;
+  final VideoPlayerValue? latestValue;
+
+  const _BetterPlayerCupertinoMuteButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.barHeight,
+    required this.iconSize,
+    required this.buttonPadding,
+    required this.backgroundColor,
+    required this.iconColor,
+    required this.onMute,
+    required this.latestValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isMuted = latestValue != null && latestValue!.volume == 0;
+    final semanticsLabel = isMuted
+        ? controller.translations.controlsUnmuteLabel
+        : controller.translations.controlsMuteLabel;
+
+    return GestureDetector(
+      onTap: onMute,
+      child: Semantics(
+        label: semanticsLabel,
+        button: true,
+        child: AnimatedOpacity(
+          opacity: controlsNotVisible ? 0.0 : 1.0,
+          duration: controlsConfiguration.controlsHideTime,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: Container(
+              decoration: BoxDecoration(color: backgroundColor),
+              child: Container(
+                height: barHeight,
+                padding: EdgeInsets.symmetric(horizontal: buttonPadding),
+                child: Icon(
+                  (latestValue != null && latestValue!.volume > 0)
+                      ? controlsConfiguration.muteIcon
+                      : controlsConfiguration.unMuteIcon,
+                  color: iconColor,
+                  size: iconSize,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerCupertinoMoreButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final double barHeight;
+  final double iconSize;
+  final double buttonPadding;
+  final Color backgroundColor;
+  final Color iconColor;
+  final VoidCallback onShowMoreClicked;
+
+  const _BetterPlayerCupertinoMoreButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.barHeight,
+    required this.iconSize,
+    required this.buttonPadding,
+    required this.backgroundColor,
+    required this.iconColor,
+    required this.onShowMoreClicked,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onShowMoreClicked,
+      child: Semantics(
+        label: controller.translations.overflowMenuLabel,
+        button: true,
+        child: AnimatedOpacity(
+          opacity: controlsNotVisible ? 0.0 : 1.0,
+          duration: controlsConfiguration.controlsHideTime,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: Container(
+              decoration: BoxDecoration(color: backgroundColor),
+              child: Container(
+                height: barHeight,
+                padding: EdgeInsets.symmetric(horizontal: buttonPadding),
+                child: Icon(
+                  controlsConfiguration.overflowMenuIcon,
+                  color: iconColor,
+                  size: iconSize,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_material_bottom_bar.dart
+++ b/lib/src/controls/better_player_material_bottom_bar.dart
@@ -1,0 +1,348 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:better_player/src/controls/better_player_material_progress_bar.dart';
+import 'package:better_player/src/controls/better_player_progress_colors.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:better_player/src/core/better_player_utils.dart';
+import 'package:better_player/src/video_player/video_player.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerMaterialBottomBar extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final VoidCallback onPlayerHide;
+  final VoidCallback onPlayPause;
+  final VoidCallback onMute;
+  final VoidCallback onExpandCollapse;
+  final VoidCallback onProgressBarDragStart;
+  final VoidCallback onProgressBarDragEnd;
+  final VoidCallback onProgressBarTapDown;
+  final VideoPlayerValue? latestValue;
+
+  const BetterPlayerMaterialBottomBar({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.onPlayerHide,
+    required this.onPlayPause,
+    required this.onMute,
+    required this.onExpandCollapse,
+    required this.onProgressBarDragStart,
+    required this.onProgressBarDragEnd,
+    required this.onProgressBarTapDown,
+    required this.latestValue,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!controller.controlsEnabled) {
+      return const SizedBox();
+    }
+    return AnimatedOpacity(
+      opacity: controlsNotVisible ? 0.0 : 1.0,
+      duration: controlsConfiguration.controlsHideTime,
+      onEnd: onPlayerHide,
+      child: Container(
+        height: controlsConfiguration.controlBarHeight + 20.0,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Expanded(
+              flex: 75,
+              child: Row(
+                children: [
+                  if (controlsConfiguration.enablePlayPause)
+                    _BetterPlayerMaterialPlayPauseButton(
+                      controller: controller,
+                      controlsConfiguration: controlsConfiguration,
+                      onPlayPause: onPlayPause,
+                    )
+                  else
+                    const SizedBox(),
+                  if (controller.isLiveStream())
+                    _BetterPlayerMaterialLiveWidget(
+                      controller: controller,
+                      controlsConfiguration: controlsConfiguration,
+                    )
+                  else if (controlsConfiguration.enableProgressText)
+                    Expanded(
+                      child: _BetterPlayerMaterialPositionWidget(
+                        controller: controller,
+                        controlsConfiguration: controlsConfiguration,
+                        latestValue: latestValue,
+                      ),
+                    )
+                  else
+                    const SizedBox(),
+                  const Spacer(),
+                  if (controlsConfiguration.enableMute)
+                    _BetterPlayerMaterialMuteButton(
+                      controller: controller,
+                      controlsConfiguration: controlsConfiguration,
+                      onMute: onMute,
+                      controlsNotVisible: controlsNotVisible,
+                      latestValue: latestValue,
+                    )
+                  else
+                    const SizedBox(),
+                  if (controlsConfiguration.enableFullscreen)
+                    _BetterPlayerMaterialFullscreenButton(
+                      controller: controller,
+                      controlsConfiguration: controlsConfiguration,
+                      onExpandCollapse: onExpandCollapse,
+                      controlsNotVisible: controlsNotVisible,
+                    )
+                  else
+                    const SizedBox(),
+                ],
+              ),
+            ),
+            if (controller.isLiveStream())
+              const SizedBox()
+            else if (controlsConfiguration.enableProgressBar)
+              _BetterPlayerMaterialProgressBarWrapper(
+                controller: controller,
+                controlsConfiguration: controlsConfiguration,
+                onProgressBarDragStart: onProgressBarDragStart,
+                onProgressBarDragEnd: onProgressBarDragEnd,
+                onProgressBarTapDown: onProgressBarTapDown,
+              )
+            else
+              const SizedBox(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialPlayPauseButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onPlayPause;
+
+  const _BetterPlayerMaterialPlayPauseButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onPlayPause,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BetterPlayerMaterialClickableWidget(
+      key: const Key('better_player_material_controls_play_pause_button'),
+      onTap: onPlayPause,
+      semanticsLabel: controller.videoPlayerController!.value.isPlaying
+          ? controller.translations.controlsPauseLabel
+          : controller.translations.controlsPlayLabel,
+      child: Container(
+        height: double.infinity,
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Icon(
+          controller.videoPlayerController!.value.isPlaying
+              ? controlsConfiguration.pauseIcon
+              : controlsConfiguration.playIcon,
+          color: controlsConfiguration.iconsColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialMuteButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onMute;
+  final bool controlsNotVisible;
+  final VideoPlayerValue? latestValue;
+
+  const _BetterPlayerMaterialMuteButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onMute,
+    required this.controlsNotVisible,
+    required this.latestValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BetterPlayerMaterialClickableWidget(
+      onTap: onMute,
+      semanticsLabel: (latestValue != null && latestValue!.volume > 0)
+          ? controller.translations.controlsMuteLabel
+          : controller.translations.controlsUnmuteLabel,
+      child: AnimatedOpacity(
+        opacity: controlsNotVisible ? 0.0 : 1.0,
+        duration: controlsConfiguration.controlsHideTime,
+        child: ClipRect(
+          child: Container(
+            height: controlsConfiguration.controlBarHeight,
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Icon(
+              (latestValue != null && latestValue!.volume > 0)
+                  ? controlsConfiguration.muteIcon
+                  : controlsConfiguration.unMuteIcon,
+              color: controlsConfiguration.iconsColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialFullscreenButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onExpandCollapse;
+  final bool controlsNotVisible;
+
+  const _BetterPlayerMaterialFullscreenButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onExpandCollapse,
+    required this.controlsNotVisible,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 12),
+      child: BetterPlayerMaterialClickableWidget(
+        key: const Key('better_player_material_controls_expand_button'),
+        onTap: onExpandCollapse,
+        semanticsLabel: controller.isFullScreen
+            ? controller.translations.controlsExitFullscreenLabel
+            : controller.translations.controlsFullscreenLabel,
+        child: AnimatedOpacity(
+          opacity: controlsNotVisible ? 0.0 : 1.0,
+          duration: controlsConfiguration.controlsHideTime,
+          child: Container(
+            height: controlsConfiguration.controlBarHeight,
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Center(
+              child: Icon(
+                controller.isFullScreen
+                    ? controlsConfiguration.fullscreenDisableIcon
+                    : controlsConfiguration.fullscreenEnableIcon,
+                color: controlsConfiguration.iconsColor,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialLiveWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const _BetterPlayerMaterialLiveWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      controller.translations.controlsLive,
+      style: TextStyle(
+        color: controlsConfiguration.liveTextColor,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialPositionWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VideoPlayerValue? latestValue;
+
+  const _BetterPlayerMaterialPositionWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.latestValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final position = latestValue != null
+        ? latestValue!.position
+        : Duration.zero;
+    final duration = latestValue != null && latestValue!.duration != null
+        ? latestValue!.duration!
+        : Duration.zero;
+
+    return Padding(
+      padding: controlsConfiguration.enablePlayPause
+          ? const EdgeInsets.only(right: 24)
+          : const EdgeInsets.symmetric(horizontal: 22),
+      child: RichText(
+        text: TextSpan(
+          text: BetterPlayerUtils.formatDuration(position),
+          style: TextStyle(
+            fontSize: 10,
+            color: controlsConfiguration.textColor,
+            decoration: TextDecoration.none,
+          ),
+          children: <TextSpan>[
+            TextSpan(
+              text: ' / ${BetterPlayerUtils.formatDuration(duration)}',
+              style: TextStyle(
+                fontSize: 10,
+                color: controlsConfiguration.textColor,
+                decoration: TextDecoration.none,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialProgressBarWrapper extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onProgressBarDragStart;
+  final VoidCallback onProgressBarDragEnd;
+  final VoidCallback onProgressBarTapDown;
+
+  const _BetterPlayerMaterialProgressBarWrapper({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onProgressBarDragStart,
+    required this.onProgressBarDragEnd,
+    required this.onProgressBarTapDown,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      flex: 40,
+      child: Container(
+        alignment: Alignment.bottomCenter,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: BetterPlayerMaterialVideoProgressBar(
+          controller.videoPlayerController,
+          controller,
+          onDragStart: onProgressBarDragStart,
+          onDragEnd: onProgressBarDragEnd,
+          onTapDown: onProgressBarTapDown,
+          colors: BetterPlayerProgressColors(
+            playedColor: controlsConfiguration.progressBarPlayedColor,
+            handleColor: controlsConfiguration.progressBarHandleColor,
+            bufferedColor: controlsConfiguration.progressBarBufferedColor,
+            backgroundColor: controlsConfiguration.progressBarBackgroundColor,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_material_bottom_bar.dart
+++ b/lib/src/controls/better_player_material_bottom_bar.dart
@@ -58,6 +58,7 @@ class BetterPlayerMaterialBottomBar extends StatelessWidget {
                       controller: controller,
                       controlsConfiguration: controlsConfiguration,
                       onPlayPause: onPlayPause,
+                      latestValue: latestValue,
                     )
                   else
                     const SizedBox(),
@@ -122,19 +123,22 @@ class _BetterPlayerMaterialPlayPauseButton extends StatelessWidget {
   final BetterPlayerController controller;
   final BetterPlayerControlsConfiguration controlsConfiguration;
   final VoidCallback onPlayPause;
+  final VideoPlayerValue? latestValue;
 
   const _BetterPlayerMaterialPlayPauseButton({
     required this.controller,
     required this.controlsConfiguration,
     required this.onPlayPause,
+    required this.latestValue,
   });
 
   @override
   Widget build(BuildContext context) {
+    final isPlaying = latestValue?.isPlaying ?? false;
     return BetterPlayerMaterialClickableWidget(
       key: const Key('better_player_material_controls_play_pause_button'),
       onTap: onPlayPause,
-      semanticsLabel: controller.videoPlayerController!.value.isPlaying
+      semanticsLabel: isPlaying
           ? controller.translations.controlsPauseLabel
           : controller.translations.controlsPlayLabel,
       child: Container(
@@ -142,7 +146,7 @@ class _BetterPlayerMaterialPlayPauseButton extends StatelessWidget {
         margin: const EdgeInsets.symmetric(horizontal: 4),
         padding: const EdgeInsets.symmetric(horizontal: 12),
         child: Icon(
-          controller.videoPlayerController!.value.isPlaying
+          isPlaying
               ? controlsConfiguration.pauseIcon
               : controlsConfiguration.playIcon,
           color: controlsConfiguration.iconsColor,

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -2,11 +2,14 @@ import 'dart:async';
 import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
 import 'package:better_player/src/controls/better_player_clickable_widget.dart';
 import 'package:better_player/src/controls/better_player_controls_state.dart';
-import 'package:better_player/src/controls/better_player_material_progress_bar.dart';
+import 'package:better_player/src/controls/better_player_material_bottom_bar.dart';
+import 'package:better_player/src/controls/better_player_material_error_widget.dart';
+import 'package:better_player/src/controls/better_player_material_loading_widget.dart';
+import 'package:better_player/src/controls/better_player_material_middle_row.dart';
+import 'package:better_player/src/controls/better_player_material_next_video_widget.dart';
+import 'package:better_player/src/controls/better_player_material_top_bar.dart';
 import 'package:better_player/src/controls/better_player_multiple_gesture_detector.dart';
-import 'package:better_player/src/controls/better_player_progress_colors.dart';
 import 'package:better_player/src/core/better_player_controller.dart';
-import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/video_player/video_player.dart';
 
 // Flutter imports:
@@ -68,7 +71,10 @@ class _BetterPlayerMaterialControlsState
     if (_latestValue?.hasError == true) {
       return ColoredBox(
         color: Colors.black,
-        child: _buildErrorWidget(),
+        child: BetterPlayerMaterialErrorWidget(
+          controller: _betterPlayerController!,
+          controlsConfiguration: _controlsConfiguration,
+        ),
       );
     }
     return GestureDetector(
@@ -97,17 +103,58 @@ class _BetterPlayerMaterialControlsState
           fit: StackFit.expand,
           children: [
             if (_wasLoading)
-              Center(child: _buildLoadingWidget())
+              Center(
+                child: BetterPlayerMaterialLoadingWidget(
+                  controlsConfiguration: _controlsConfiguration,
+                ),
+              )
             else
-              _buildHitArea(),
+              BetterPlayerMaterialHitArea(
+                controller: _betterPlayerController!,
+                controlsConfiguration: _controlsConfiguration,
+                controlsNotVisible: controlsNotVisible,
+                onSkipBack: skipBack,
+                onSkipForward: skipForward,
+                onReplay: _onReplay,
+                latestValue: _latestValue,
+                isVideoFinished: isVideoFinished(_latestValue),
+              ),
             Positioned(
               top: 0,
               left: 0,
               right: 0,
-              child: _buildTopBar(),
+              child: BetterPlayerMaterialTopBar(
+                controller: _betterPlayerController!,
+                controlsConfiguration: _controlsConfiguration,
+                controlsNotVisible: controlsNotVisible,
+                onPlayerHide: _onPlayerHide,
+                onShowMoreClicked: onShowMoreClicked,
+              ),
             ),
-            Positioned(bottom: 0, left: 0, right: 0, child: _buildBottomBar()),
-            _buildNextVideoWidget(),
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: BetterPlayerMaterialBottomBar(
+                controller: _betterPlayerController!,
+                controlsConfiguration: _controlsConfiguration,
+                controlsNotVisible: controlsNotVisible,
+                onPlayerHide: _onPlayerHide,
+                onPlayPause: _onPlayPause,
+                onMute: _onMute,
+                onExpandCollapse: _onExpandCollapse,
+                onProgressBarDragStart: () {
+                  _hideTimer?.cancel();
+                },
+                onProgressBarDragEnd: _startHideTimer,
+                onProgressBarTapDown: cancelAndRestartTimer,
+                latestValue: _latestValue,
+              ),
+            ),
+            BetterPlayerMaterialNextVideoWidget(
+              controller: _betterPlayerController!,
+              controlsConfiguration: _controlsConfiguration,
+            ),
           ],
         ),
       ),
@@ -143,500 +190,32 @@ class _BetterPlayerMaterialControlsState
     super.didChangeDependencies();
   }
 
-  Widget _buildErrorWidget() {
-    final errorBuilder =
-        _betterPlayerController!.betterPlayerConfiguration.errorBuilder;
-    if (errorBuilder != null) {
-      return errorBuilder(
-        context,
-        _betterPlayerController!.videoPlayerController!.value.errorDescription,
-      );
+  void _onMute() {
+    cancelAndRestartTimer();
+    if (_latestValue!.volume == 0) {
+      _betterPlayerController!.setVolume(_latestVolume ?? 0.5);
     } else {
-      final textStyle = TextStyle(color: _controlsConfiguration.textColor);
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.warning,
-              color: _controlsConfiguration.iconsColor,
-              size: 42,
-            ),
-            Text(
-              _betterPlayerController!.translations.generalDefaultError,
-              style: textStyle,
-            ),
-            if (_controlsConfiguration.enableRetry)
-              TextButton(
-                onPressed: () {
-                  _betterPlayerController!.retryDataSource();
-                },
-                child: Text(
-                  _betterPlayerController!.translations.generalRetry,
-                  style: textStyle.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
-          ],
-        ),
-      );
+      _latestVolume = _controller!.value.volume;
+      _betterPlayerController!.setVolume(0);
     }
   }
 
-  Widget _buildTopBar() {
-    if (!betterPlayerController!.controlsEnabled) {
-      return const SizedBox();
-    }
-
-    return Container(
-      child: (_controlsConfiguration.enableOverflowMenu)
-          ? AnimatedOpacity(
-              opacity: controlsNotVisible ? 0.0 : 1.0,
-              duration: _controlsConfiguration.controlsHideTime,
-              onEnd: _onPlayerHide,
-              child: Container(
-                height: _controlsConfiguration.controlBarHeight,
-                width: double.infinity,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    if (_controlsConfiguration.enablePip)
-                      _buildPipButtonWrapperWidget(
-                        controlsNotVisible,
-                        _onPlayerHide,
-                      )
-                    else
-                      const SizedBox(),
-                    _buildMoreButton(),
-                  ],
-                ),
-              ),
-            )
-          : const SizedBox(),
-    );
-  }
-
-  Widget _buildPipButton() {
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        betterPlayerController!.enablePictureInPicture(
-          betterPlayerController!.betterPlayerGlobalKey!,
-        );
-      },
-      semanticsLabel: _betterPlayerController!.translations.controlsPipLabel,
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: Icon(
-          betterPlayerControlsConfiguration.pipMenuIcon,
-          color: betterPlayerControlsConfiguration.iconsColor,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPipButtonWrapperWidget(
-    bool hideStuff,
-    void Function() onPlayerHide,
-  ) {
-    return FutureBuilder<bool>(
-      future: betterPlayerController!.isPictureInPictureSupported(),
-      builder: (context, snapshot) {
-        final isPipSupported = snapshot.data ?? false;
-        if (isPipSupported &&
-            _betterPlayerController!.betterPlayerGlobalKey != null) {
-          return AnimatedOpacity(
-            opacity: hideStuff ? 0.0 : 1.0,
-            duration: betterPlayerControlsConfiguration.controlsHideTime,
-            onEnd: onPlayerHide,
-            child: Container(
-              height: betterPlayerControlsConfiguration.controlBarHeight,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  _buildPipButton(),
-                ],
-              ),
-            ),
-          );
-        } else {
-          return const SizedBox();
-        }
-      },
-    );
-  }
-
-  Widget _buildMoreButton() {
-    return BetterPlayerMaterialClickableWidget(
-      onTap: onShowMoreClicked,
-      semanticsLabel: _betterPlayerController!.translations.overflowMenuLabel,
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: Icon(
-          _controlsConfiguration.overflowMenuIcon,
-          color: _controlsConfiguration.iconsColor,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBottomBar() {
-    if (!betterPlayerController!.controlsEnabled) {
-      return const SizedBox();
-    }
-    return AnimatedOpacity(
-      opacity: controlsNotVisible ? 0.0 : 1.0,
-      duration: _controlsConfiguration.controlsHideTime,
-      onEnd: _onPlayerHide,
-      child: Container(
-        height: _controlsConfiguration.controlBarHeight + 20.0,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: <Widget>[
-            Expanded(
-              flex: 75,
-              child: Row(
-                children: [
-                  if (_controlsConfiguration.enablePlayPause)
-                    _buildPlayPause(_controller!)
-                  else
-                    const SizedBox(),
-                  if (_betterPlayerController!.isLiveStream())
-                    _buildLiveWidget()
-                  else if (_controlsConfiguration.enableProgressText)
-                    Expanded(child: _buildPosition())
-                  else
-                    const SizedBox(),
-                  const Spacer(),
-                  if (_controlsConfiguration.enableMute)
-                    _buildMuteButton(_controller)
-                  else
-                    const SizedBox(),
-                  if (_controlsConfiguration.enableFullscreen)
-                    _buildExpandButton()
-                  else
-                    const SizedBox(),
-                ],
-              ),
-            ),
-            if (_betterPlayerController!.isLiveStream())
-              const SizedBox()
-            else if (_controlsConfiguration.enableProgressBar)
-              _buildProgressBar()
-            else
-              const SizedBox(),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLiveWidget() {
-    return Text(
-      _betterPlayerController!.translations.controlsLive,
-      style: TextStyle(
-        color: _controlsConfiguration.liveTextColor,
-        fontWeight: FontWeight.bold,
-      ),
-    );
-  }
-
-  Widget _buildExpandButton() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 12),
-      child: BetterPlayerMaterialClickableWidget(
-        key: const Key('better_player_material_controls_expand_button'),
-        onTap: _onExpandCollapse,
-        semanticsLabel: _betterPlayerController!.isFullScreen
-            ? _betterPlayerController!.translations.controlsExitFullscreenLabel
-            : _betterPlayerController!.translations.controlsFullscreenLabel,
-        child: AnimatedOpacity(
-          opacity: controlsNotVisible ? 0.0 : 1.0,
-          duration: _controlsConfiguration.controlsHideTime,
-          child: Container(
-            height: _controlsConfiguration.controlBarHeight,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Center(
-              child: Icon(
-                _betterPlayerController!.isFullScreen
-                    ? _controlsConfiguration.fullscreenDisableIcon
-                    : _controlsConfiguration.fullscreenEnableIcon,
-                color: _controlsConfiguration.iconsColor,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildHitArea() {
-    if (!betterPlayerController!.controlsEnabled) {
-      return const SizedBox();
-    }
-    return Container(
-      child: Center(
-        child: AnimatedOpacity(
-          opacity: controlsNotVisible ? 0.0 : 1.0,
-          duration: _controlsConfiguration.controlsHideTime,
-          child: _buildMiddleRow(),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMiddleRow() {
-    return Container(
-      color: _controlsConfiguration.controlBarColor,
-      width: double.infinity,
-      height: double.infinity,
-      child: _betterPlayerController?.isLiveStream() == true
-          ? const SizedBox()
-          : Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                if (_controlsConfiguration.enableSkips)
-                  Expanded(child: _buildSkipButton())
-                else
-                  const SizedBox(),
-                Expanded(child: _buildReplayButton(_controller!)),
-                if (_controlsConfiguration.enableSkips)
-                  Expanded(child: _buildForwardButton())
-                else
-                  const SizedBox(),
-              ],
-            ),
-    );
-  }
-
-  Widget _buildHitAreaClickableButton({
-    required void Function() onClicked,
-    Widget? icon,
-    Key? key,
-    String? semanticsLabel,
-  }) {
-    return Container(
-      constraints: const BoxConstraints(maxHeight: 80, maxWidth: 80),
-      child: BetterPlayerMaterialClickableWidget(
-        key: key,
-        onTap: onClicked,
-        semanticsLabel: semanticsLabel,
-        child: Align(
-          child: Container(
-            decoration: BoxDecoration(
-              color: Colors.transparent,
-              borderRadius: BorderRadius.circular(48),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(8),
-              child: Stack(
-                children: [icon!],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSkipButton() {
-    return _buildHitAreaClickableButton(
-      key: const Key('better_player_material_controls_skip_back_button'),
-      icon: Icon(
-        _controlsConfiguration.skipBackIcon,
-        size: 24,
-        color: _controlsConfiguration.iconsColor,
-      ),
-      onClicked: skipBack,
-      semanticsLabel:
-          _betterPlayerController!.translations.controlsSkipBackwardLabel,
-    );
-  }
-
-  Widget _buildForwardButton() {
-    return _buildHitAreaClickableButton(
-      key: const Key('better_player_material_controls_skip_forward_button'),
-      icon: Icon(
-        _controlsConfiguration.skipForwardIcon,
-        size: 24,
-        color: _controlsConfiguration.iconsColor,
-      ),
-      onClicked: skipForward,
-      semanticsLabel:
-          _betterPlayerController!.translations.controlsSkipForwardLabel,
-    );
-  }
-
-  Widget _buildReplayButton(VideoPlayerController controller) {
+  void _onReplay() {
     final isFinished = isVideoFinished(_latestValue);
-    final isPlaying = controller.value.isPlaying;
-
-    var semanticsLabel = isPlaying
-        ? _betterPlayerController!.translations.controlsPauseLabel
-        : _betterPlayerController!.translations.controlsPlayLabel;
     if (isFinished) {
-      semanticsLabel = _betterPlayerController!.translations.controlsPlayLabel;
+      if (_latestValue != null && _latestValue!.isPlaying) {
+        if (_displayTapped) {
+          changePlayerControlsNotVisible(true);
+        } else {
+          cancelAndRestartTimer();
+        }
+      } else {
+        _onPlayPause();
+        changePlayerControlsNotVisible(true);
+      }
+    } else {
+      _onPlayPause();
     }
-
-    return _buildHitAreaClickableButton(
-      semanticsLabel: semanticsLabel,
-      icon: isFinished
-          ? Icon(
-              Icons.replay,
-              size: 42,
-              color: _controlsConfiguration.iconsColor,
-            )
-          : Icon(
-              isPlaying
-                  ? _controlsConfiguration.pauseIcon
-                  : _controlsConfiguration.playIcon,
-              size: 42,
-              color: _controlsConfiguration.iconsColor,
-            ),
-      onClicked: () {
-        if (isFinished) {
-          if (_latestValue != null && _latestValue!.isPlaying) {
-            if (_displayTapped) {
-              changePlayerControlsNotVisible(true);
-            } else {
-              cancelAndRestartTimer();
-            }
-          } else {
-            _onPlayPause();
-            changePlayerControlsNotVisible(true);
-          }
-        } else {
-          _onPlayPause();
-        }
-      },
-    );
-  }
-
-  Widget _buildNextVideoWidget() {
-    return StreamBuilder<int?>(
-      stream: _betterPlayerController!.nextVideoTimeStream,
-      builder: (context, snapshot) {
-        final time = snapshot.data;
-        if (time != null && time > 0) {
-          return BetterPlayerMaterialClickableWidget(
-            onTap: () {
-              _betterPlayerController!.playNextVideo();
-            },
-            child: Align(
-              alignment: Alignment.bottomRight,
-              child: Container(
-                margin: EdgeInsets.only(
-                  bottom: _controlsConfiguration.controlBarHeight + 20,
-                  right: 24,
-                ),
-                decoration: BoxDecoration(
-                  color: _controlsConfiguration.controlBarColor,
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Text(
-                    '${_betterPlayerController!.translations.controlsNextVideoIn} $time...',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                ),
-              ),
-            ),
-          );
-        } else {
-          return const SizedBox();
-        }
-      },
-    );
-  }
-
-  Widget _buildMuteButton(
-    VideoPlayerController? controller,
-  ) {
-    return BetterPlayerMaterialClickableWidget(
-      onTap: () {
-        cancelAndRestartTimer();
-        if (_latestValue!.volume == 0) {
-          _betterPlayerController!.setVolume(_latestVolume ?? 0.5);
-        } else {
-          _latestVolume = controller!.value.volume;
-          _betterPlayerController!.setVolume(0);
-        }
-      },
-      semanticsLabel: (_latestValue != null && _latestValue!.volume > 0)
-          ? _betterPlayerController!.translations.controlsMuteLabel
-          : _betterPlayerController!.translations.controlsUnmuteLabel,
-      child: AnimatedOpacity(
-        opacity: controlsNotVisible ? 0.0 : 1.0,
-        duration: _controlsConfiguration.controlsHideTime,
-        child: ClipRect(
-          child: Container(
-            height: _controlsConfiguration.controlBarHeight,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Icon(
-              (_latestValue != null && _latestValue!.volume > 0)
-                  ? _controlsConfiguration.muteIcon
-                  : _controlsConfiguration.unMuteIcon,
-              color: _controlsConfiguration.iconsColor,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPlayPause(VideoPlayerController controller) {
-    return BetterPlayerMaterialClickableWidget(
-      key: const Key('better_player_material_controls_play_pause_button'),
-      onTap: _onPlayPause,
-      semanticsLabel: controller.value.isPlaying
-          ? _betterPlayerController!.translations.controlsPauseLabel
-          : _betterPlayerController!.translations.controlsPlayLabel,
-      child: Container(
-        height: double.infinity,
-        margin: const EdgeInsets.symmetric(horizontal: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Icon(
-          controller.value.isPlaying
-              ? _controlsConfiguration.pauseIcon
-              : _controlsConfiguration.playIcon,
-          color: _controlsConfiguration.iconsColor,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPosition() {
-    final position = _latestValue != null
-        ? _latestValue!.position
-        : Duration.zero;
-    final duration = _latestValue != null && _latestValue!.duration != null
-        ? _latestValue!.duration!
-        : Duration.zero;
-
-    return Padding(
-      padding: _controlsConfiguration.enablePlayPause
-          ? const EdgeInsets.only(right: 24)
-          : const EdgeInsets.symmetric(horizontal: 22),
-      child: RichText(
-        text: TextSpan(
-          text: BetterPlayerUtils.formatDuration(position),
-          style: TextStyle(
-            fontSize: 10,
-            color: _controlsConfiguration.textColor,
-            decoration: TextDecoration.none,
-          ),
-          children: <TextSpan>[
-            TextSpan(
-              text: ' / ${BetterPlayerUtils.formatDuration(duration)}',
-              style: TextStyle(
-                fontSize: 10,
-                color: _controlsConfiguration.textColor,
-                decoration: TextDecoration.none,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 
   @override
@@ -736,52 +315,8 @@ class _BetterPlayerMaterialControlsState
     }
   }
 
-  Widget _buildProgressBar() {
-    return Expanded(
-      flex: 40,
-      child: Container(
-        alignment: Alignment.bottomCenter,
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: BetterPlayerMaterialVideoProgressBar(
-          _controller,
-          _betterPlayerController,
-          onDragStart: () {
-            _hideTimer?.cancel();
-          },
-          onDragEnd: () {
-            _startHideTimer();
-          },
-          onTapDown: () {
-            cancelAndRestartTimer();
-          },
-          colors: BetterPlayerProgressColors(
-            playedColor: _controlsConfiguration.progressBarPlayedColor,
-            handleColor: _controlsConfiguration.progressBarHandleColor,
-            bufferedColor: _controlsConfiguration.progressBarBufferedColor,
-            backgroundColor: _controlsConfiguration.progressBarBackgroundColor,
-          ),
-        ),
-      ),
-    );
-  }
-
   void _onPlayerHide() {
     _betterPlayerController!.toggleControlsVisibility(!controlsNotVisible);
     widget.onControlsVisibilityChanged(!controlsNotVisible);
-  }
-
-  Widget? _buildLoadingWidget() {
-    if (_controlsConfiguration.loadingWidget != null) {
-      return ColoredBox(
-        color: _controlsConfiguration.controlBarColor,
-        child: _controlsConfiguration.loadingWidget,
-      );
-    }
-
-    return CircularProgressIndicator(
-      valueColor: AlwaysStoppedAnimation<Color>(
-        _controlsConfiguration.loadingColor,
-      ),
-    );
   }
 }

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -192,6 +192,9 @@ class _BetterPlayerMaterialControlsState
 
   void _onMute() {
     cancelAndRestartTimer();
+    if (_latestValue == null) {
+      return;
+    }
     if (_latestValue!.volume == 0) {
       _betterPlayerController!.setVolume(_latestVolume ?? 0.5);
     } else {

--- a/lib/src/controls/better_player_material_error_widget.dart
+++ b/lib/src/controls/better_player_material_error_widget.dart
@@ -1,0 +1,51 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerMaterialErrorWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerMaterialErrorWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final errorBuilder = controller.betterPlayerConfiguration.errorBuilder;
+    if (errorBuilder != null) {
+      return errorBuilder(
+        context,
+        controller.videoPlayerController!.value.errorDescription,
+      );
+    } else {
+      final textStyle = TextStyle(color: controlsConfiguration.textColor);
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.warning,
+              color: controlsConfiguration.iconsColor,
+              size: 42,
+            ),
+            Text(
+              controller.translations.generalDefaultError,
+              style: textStyle,
+            ),
+            if (controlsConfiguration.enableRetry)
+              TextButton(
+                onPressed: controller.retryDataSource,
+                child: Text(
+                  controller.translations.generalRetry,
+                  style: textStyle.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+  }
+}

--- a/lib/src/controls/better_player_material_loading_widget.dart
+++ b/lib/src/controls/better_player_material_loading_widget.dart
@@ -1,0 +1,27 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerMaterialLoadingWidget extends StatelessWidget {
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerMaterialLoadingWidget({
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (controlsConfiguration.loadingWidget != null) {
+      return ColoredBox(
+        color: controlsConfiguration.controlBarColor,
+        child: controlsConfiguration.loadingWidget,
+      );
+    }
+
+    return CircularProgressIndicator(
+      valueColor: AlwaysStoppedAnimation<Color>(
+        controlsConfiguration.loadingColor,
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_material_middle_row.dart
+++ b/lib/src/controls/better_player_material_middle_row.dart
@@ -1,0 +1,218 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:better_player/src/video_player/video_player.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerMaterialHitArea extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final VoidCallback onSkipBack;
+  final VoidCallback onSkipForward;
+  final VoidCallback onReplay;
+  final VideoPlayerValue? latestValue;
+  final bool isVideoFinished;
+
+  const BetterPlayerMaterialHitArea({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.onSkipBack,
+    required this.onSkipForward,
+    required this.onReplay,
+    required this.latestValue,
+    required this.isVideoFinished,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!controller.controlsEnabled) {
+      return const SizedBox();
+    }
+    return Container(
+      child: Center(
+        child: AnimatedOpacity(
+          opacity: controlsNotVisible ? 0.0 : 1.0,
+          duration: controlsConfiguration.controlsHideTime,
+          child: BetterPlayerMaterialMiddleRow(
+            controller: controller,
+            controlsConfiguration: controlsConfiguration,
+            onSkipBack: onSkipBack,
+            onSkipForward: onSkipForward,
+            onReplay: onReplay,
+            latestValue: latestValue,
+            isVideoFinished: isVideoFinished,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class BetterPlayerMaterialMiddleRow extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onSkipBack;
+  final VoidCallback onSkipForward;
+  final VoidCallback onReplay;
+  final VideoPlayerValue? latestValue;
+  final bool isVideoFinished;
+
+  const BetterPlayerMaterialMiddleRow({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onSkipBack,
+    required this.onSkipForward,
+    required this.onReplay,
+    required this.latestValue,
+    required this.isVideoFinished,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: controlsConfiguration.controlBarColor,
+      width: double.infinity,
+      height: double.infinity,
+      child: controller.isLiveStream()
+          ? const SizedBox()
+          : Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                if (controlsConfiguration.enableSkips)
+                  Expanded(
+                    child: _BetterPlayerMaterialHitAreaClickableButton(
+                      key: const Key(
+                        'better_player_material_controls_skip_back_button',
+                      ),
+                      icon: Icon(
+                        controlsConfiguration.skipBackIcon,
+                        size: 24,
+                        color: controlsConfiguration.iconsColor,
+                      ),
+                      onClicked: onSkipBack,
+                      semanticsLabel:
+                          controller.translations.controlsSkipBackwardLabel,
+                    ),
+                  )
+                else
+                  const SizedBox(),
+                Expanded(
+                  child: _BetterPlayerMaterialReplayButton(
+                    controller: controller,
+                    controlsConfiguration: controlsConfiguration,
+                    onReplay: onReplay,
+                    latestValue: latestValue,
+                    isVideoFinished: isVideoFinished,
+                  ),
+                ),
+                if (controlsConfiguration.enableSkips)
+                  Expanded(
+                    child: _BetterPlayerMaterialHitAreaClickableButton(
+                      key: const Key(
+                        'better_player_material_controls_skip_forward_button',
+                      ),
+                      icon: Icon(
+                        controlsConfiguration.skipForwardIcon,
+                        size: 24,
+                        color: controlsConfiguration.iconsColor,
+                      ),
+                      onClicked: onSkipForward,
+                      semanticsLabel:
+                          controller.translations.controlsSkipForwardLabel,
+                    ),
+                  )
+                else
+                  const SizedBox(),
+              ],
+            ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialHitAreaClickableButton extends StatelessWidget {
+  final VoidCallback onClicked;
+  final Widget icon;
+  final String? semanticsLabel;
+
+  const _BetterPlayerMaterialHitAreaClickableButton({
+    required this.onClicked,
+    required this.icon,
+    this.semanticsLabel,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 80, maxWidth: 80),
+      child: BetterPlayerMaterialClickableWidget(
+        onTap: onClicked,
+        semanticsLabel: semanticsLabel,
+        child: Align(
+          child: Container(
+            decoration: BoxDecoration(
+              color: Colors.transparent,
+              borderRadius: BorderRadius.circular(48),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Stack(
+                children: [icon],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BetterPlayerMaterialReplayButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onReplay;
+  final VideoPlayerValue? latestValue;
+  final bool isVideoFinished;
+
+  const _BetterPlayerMaterialReplayButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onReplay,
+    required this.latestValue,
+    required this.isVideoFinished,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isPlaying = controller.videoPlayerController!.value.isPlaying;
+
+    var semanticsLabel = isPlaying
+        ? controller.translations.controlsPauseLabel
+        : controller.translations.controlsPlayLabel;
+    if (isVideoFinished) {
+      semanticsLabel = controller.translations.controlsPlayLabel;
+    }
+
+    return _BetterPlayerMaterialHitAreaClickableButton(
+      semanticsLabel: semanticsLabel,
+      icon: isVideoFinished
+          ? Icon(
+              Icons.replay,
+              size: 42,
+              color: controlsConfiguration.iconsColor,
+            )
+          : Icon(
+              isPlaying
+                  ? controlsConfiguration.pauseIcon
+                  : controlsConfiguration.playIcon,
+              size: 42,
+              color: controlsConfiguration.iconsColor,
+            ),
+      onClicked: onReplay,
+    );
+  }
+}

--- a/lib/src/controls/better_player_material_next_video_widget.dart
+++ b/lib/src/controls/better_player_material_next_video_widget.dart
@@ -1,0 +1,52 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerMaterialNextVideoWidget extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerMaterialNextVideoWidget({
+    required this.controller,
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<int?>(
+      stream: controller.nextVideoTimeStream,
+      builder: (context, snapshot) {
+        final time = snapshot.data;
+        if (time != null && time > 0) {
+          return BetterPlayerMaterialClickableWidget(
+            onTap: controller.playNextVideo,
+            child: Align(
+              alignment: Alignment.bottomRight,
+              child: Container(
+                margin: EdgeInsets.only(
+                  bottom: controlsConfiguration.controlBarHeight + 20,
+                  right: 24,
+                ),
+                decoration: BoxDecoration(
+                  color: controlsConfiguration.controlBarColor,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text(
+                    '${controller.translations.controlsNextVideoIn} $time...',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+              ),
+            ),
+          );
+        } else {
+          return const SizedBox();
+        }
+      },
+    );
+  }
+}

--- a/lib/src/controls/better_player_material_top_bar.dart
+++ b/lib/src/controls/better_player_material_top_bar.dart
@@ -1,0 +1,144 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerMaterialTopBar extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final VoidCallback onPlayerHide;
+  final VoidCallback onShowMoreClicked;
+
+  const BetterPlayerMaterialTopBar({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.onPlayerHide,
+    required this.onShowMoreClicked,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!controller.controlsEnabled) {
+      return const SizedBox();
+    }
+
+    return Container(
+      child: (controlsConfiguration.enableOverflowMenu)
+          ? AnimatedOpacity(
+              opacity: controlsNotVisible ? 0.0 : 1.0,
+              duration: controlsConfiguration.controlsHideTime,
+              onEnd: onPlayerHide,
+              child: Container(
+                height: controlsConfiguration.controlBarHeight,
+                width: double.infinity,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (controlsConfiguration.enablePip)
+                      _BetterPlayerMaterialPipButtonWrapper(
+                        controller: controller,
+                        controlsConfiguration: controlsConfiguration,
+                        controlsNotVisible: controlsNotVisible,
+                        onPlayerHide: onPlayerHide,
+                      )
+                    else
+                      const SizedBox(),
+                    _BetterPlayerMaterialMoreButton(
+                      controller: controller,
+                      controlsConfiguration: controlsConfiguration,
+                      onShowMoreClicked: onShowMoreClicked,
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : const SizedBox(),
+    );
+  }
+}
+
+class _BetterPlayerMaterialPipButtonWrapper extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool controlsNotVisible;
+  final VoidCallback onPlayerHide;
+
+  const _BetterPlayerMaterialPipButtonWrapper({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.controlsNotVisible,
+    required this.onPlayerHide,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: controller.isPictureInPictureSupported(),
+      builder: (context, snapshot) {
+        final isPipSupported = snapshot.data ?? false;
+        if (isPipSupported && controller.betterPlayerGlobalKey != null) {
+          return AnimatedOpacity(
+            opacity: controlsNotVisible ? 0.0 : 1.0,
+            duration: controlsConfiguration.controlsHideTime,
+            onEnd: onPlayerHide,
+            child: Container(
+              height: controlsConfiguration.controlBarHeight,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  BetterPlayerMaterialClickableWidget(
+                    onTap: () {
+                      controller.enablePictureInPicture(
+                        controller.betterPlayerGlobalKey!,
+                      );
+                    },
+                    semanticsLabel: controller.translations.controlsPipLabel,
+                    child: Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Icon(
+                        controlsConfiguration.pipMenuIcon,
+                        color: controlsConfiguration.iconsColor,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        } else {
+          return const SizedBox();
+        }
+      },
+    );
+  }
+}
+
+class _BetterPlayerMaterialMoreButton extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onShowMoreClicked;
+
+  const _BetterPlayerMaterialMoreButton({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onShowMoreClicked,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BetterPlayerMaterialClickableWidget(
+      onTap: onShowMoreClicked,
+      semanticsLabel: controller.translations.overflowMenuLabel,
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Icon(
+          controlsConfiguration.overflowMenuIcon,
+          color: controlsConfiguration.iconsColor,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_material_top_bar.dart
+++ b/lib/src/controls/better_player_material_top_bar.dart
@@ -60,7 +60,7 @@ class BetterPlayerMaterialTopBar extends StatelessWidget {
   }
 }
 
-class _BetterPlayerMaterialPipButtonWrapper extends StatelessWidget {
+class _BetterPlayerMaterialPipButtonWrapper extends StatefulWidget {
   final BetterPlayerController controller;
   final BetterPlayerControlsConfiguration controlsConfiguration;
   final bool controlsNotVisible;
@@ -74,33 +74,59 @@ class _BetterPlayerMaterialPipButtonWrapper extends StatelessWidget {
   });
 
   @override
+  State<_BetterPlayerMaterialPipButtonWrapper> createState() =>
+      _BetterPlayerMaterialPipButtonWrapperState();
+}
+
+class _BetterPlayerMaterialPipButtonWrapperState
+    extends State<_BetterPlayerMaterialPipButtonWrapper> {
+  late Future<bool> _isPipSupportedFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _isPipSupportedFuture = widget.controller.isPictureInPictureSupported();
+  }
+
+  @override
+  void didUpdateWidget(
+    covariant _BetterPlayerMaterialPipButtonWrapper oldWidget,
+  ) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      _isPipSupportedFuture = widget.controller.isPictureInPictureSupported();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return FutureBuilder<bool>(
-      future: controller.isPictureInPictureSupported(),
+      future: _isPipSupportedFuture,
       builder: (context, snapshot) {
         final isPipSupported = snapshot.data ?? false;
-        if (isPipSupported && controller.betterPlayerGlobalKey != null) {
+        if (isPipSupported && widget.controller.betterPlayerGlobalKey != null) {
           return AnimatedOpacity(
-            opacity: controlsNotVisible ? 0.0 : 1.0,
-            duration: controlsConfiguration.controlsHideTime,
-            onEnd: onPlayerHide,
+            opacity: widget.controlsNotVisible ? 0.0 : 1.0,
+            duration: widget.controlsConfiguration.controlsHideTime,
+            onEnd: widget.onPlayerHide,
             child: Container(
-              height: controlsConfiguration.controlBarHeight,
+              height: widget.controlsConfiguration.controlBarHeight,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   BetterPlayerMaterialClickableWidget(
                     onTap: () {
-                      controller.enablePictureInPicture(
-                        controller.betterPlayerGlobalKey!,
+                      widget.controller.enablePictureInPicture(
+                        widget.controller.betterPlayerGlobalKey!,
                       );
                     },
-                    semanticsLabel: controller.translations.controlsPipLabel,
+                    semanticsLabel:
+                        widget.controller.translations.controlsPipLabel,
                     child: Padding(
                       padding: const EdgeInsets.all(8),
                       child: Icon(
-                        controlsConfiguration.pipMenuIcon,
-                        color: controlsConfiguration.iconsColor,
+                        widget.controlsConfiguration.pipMenuIcon,
+                        color: widget.controlsConfiguration.iconsColor,
                       ),
                     ),
                   ),

--- a/lib/src/controls/better_player_overflow_menu.dart
+++ b/lib/src/controls/better_player_overflow_menu.dart
@@ -1,0 +1,127 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:better_player/src/core/better_player_controller.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerOverflowMenu extends StatelessWidget {
+  final BetterPlayerController controller;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final VoidCallback onPlaybackSpeedClicked;
+  final VoidCallback onSubtitlesClicked;
+  final VoidCallback onQualitiesClicked;
+  final VoidCallback onAudioTracksClicked;
+
+  const BetterPlayerOverflowMenu({
+    required this.controller,
+    required this.controlsConfiguration,
+    required this.onPlaybackSpeedClicked,
+    required this.onSubtitlesClicked,
+    required this.onQualitiesClicked,
+    required this.onAudioTracksClicked,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final translations = controller.translations;
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          if (controlsConfiguration.enablePlaybackSpeed)
+            BetterPlayerOverflowMenuItemWidget(
+              icon: controlsConfiguration.playbackSpeedIcon,
+              name: translations.overflowMenuPlaybackSpeed,
+              onTap: onPlaybackSpeedClicked,
+              controlsConfiguration: controlsConfiguration,
+            ),
+          if (controlsConfiguration.enableSubtitles)
+            BetterPlayerOverflowMenuItemWidget(
+              icon: controlsConfiguration.subtitlesIcon,
+              name: translations.overflowMenuSubtitles,
+              onTap: onSubtitlesClicked,
+              controlsConfiguration: controlsConfiguration,
+            ),
+          if (controlsConfiguration.enableQualities)
+            BetterPlayerOverflowMenuItemWidget(
+              icon: controlsConfiguration.qualitiesIcon,
+              name: translations.overflowMenuQuality,
+              onTap: onQualitiesClicked,
+              controlsConfiguration: controlsConfiguration,
+            ),
+          if (controlsConfiguration.enableAudioTracks)
+            BetterPlayerOverflowMenuItemWidget(
+              icon: controlsConfiguration.audioTracksIcon,
+              name: translations.overflowMenuAudioTracks,
+              onTap: onAudioTracksClicked,
+              controlsConfiguration: controlsConfiguration,
+            ),
+          if (controlsConfiguration.overflowMenuCustomItems.isNotEmpty)
+            ...controlsConfiguration.overflowMenuCustomItems.map(
+              (customItem) => BetterPlayerOverflowMenuItemWidget(
+                icon: customItem.icon,
+                name: customItem.title,
+                onTap: () {
+                  Navigator.of(context).pop();
+                  customItem.onClicked.call();
+                },
+                controlsConfiguration: controlsConfiguration,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class BetterPlayerOverflowMenuItemWidget extends StatelessWidget {
+  final IconData icon;
+  final String name;
+  final VoidCallback onTap;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+  final bool isSelected;
+
+  const BetterPlayerOverflowMenuItemWidget({
+    required this.icon,
+    required this.name,
+    required this.onTap,
+    required this.controlsConfiguration,
+    this.isSelected = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BetterPlayerMaterialClickableWidget(
+      onTap: onTap,
+      semanticsLabel: name,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
+        child: Row(
+          children: [
+            const SizedBox(width: 8),
+            Icon(
+              icon,
+              color: controlsConfiguration.overflowMenuIconsColor,
+            ),
+            const SizedBox(width: 16),
+            Text(
+              name,
+              style: _getOverflowMenuElementTextStyle(isSelected),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  TextStyle _getOverflowMenuElementTextStyle(bool isSelected) {
+    return TextStyle(
+      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+      color: isSelected
+          ? controlsConfiguration.overflowModalTextColor
+          : controlsConfiguration.overflowModalTextColor.withValues(
+              alpha: 0.7,
+            ),
+    );
+  }
+}

--- a/lib/src/controls/better_player_selection_list_item_widget.dart
+++ b/lib/src/controls/better_player_selection_list_item_widget.dart
@@ -1,0 +1,57 @@
+import 'package:better_player/src/configuration/better_player_controls_configuration.dart';
+import 'package:better_player/src/controls/better_player_clickable_widget.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerSelectionListItemWidget extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final BetterPlayerControlsConfiguration controlsConfiguration;
+
+  const BetterPlayerSelectionListItemWidget({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+    required this.controlsConfiguration,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BetterPlayerMaterialClickableWidget(
+      onTap: onTap,
+      semanticsLabel: label,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+        child: Row(
+          children: [
+            SizedBox(width: isSelected ? 8 : 16),
+            Visibility(
+              visible: isSelected,
+              child: Icon(
+                Icons.check_outlined,
+                color: controlsConfiguration.overflowModalTextColor,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Text(
+              label,
+              style: _getTextStyle(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  TextStyle _getTextStyle() {
+    return TextStyle(
+      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+      color: isSelected
+          ? controlsConfiguration.overflowModalTextColor
+          : controlsConfiguration.overflowModalTextColor.withValues(
+              alpha: 0.7,
+            ),
+    );
+  }
+}

--- a/lib/src/core/better_player.dart
+++ b/lib/src/core/better_player.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/configuration/better_player_controller_event.dart';
+import 'package:better_player/src/core/better_player_full_screen_video.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/core/better_player_with_controls.dart';
 import 'package:flutter/services.dart';
@@ -168,22 +169,7 @@ class _BetterPlayerState extends State<BetterPlayer>
   Widget build(BuildContext context) {
     return BetterPlayerControllerProvider(
       controller: widget.controller,
-      child: _buildPlayer(),
-    );
-  }
-
-  Widget _buildFullScreenVideo(
-    BuildContext context,
-    Animation<double> animation,
-    BetterPlayerControllerProvider controllerProvider,
-  ) {
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      body: Container(
-        alignment: Alignment.center,
-        color: Colors.black,
-        child: controllerProvider,
-      ),
+      child: _BetterPlayerVideoWithVisibility(controller: widget.controller),
     );
   }
 
@@ -196,7 +182,9 @@ class _BetterPlayerState extends State<BetterPlayer>
     return AnimatedBuilder(
       animation: animation,
       builder: (BuildContext context, Widget? child) {
-        return _buildFullScreenVideo(context, animation, controllerProvider);
+        return BetterPlayerFullScreenVideo(
+          controllerProvider: controllerProvider,
+        );
       },
     );
   }
@@ -208,7 +196,7 @@ class _BetterPlayerState extends State<BetterPlayer>
   ) {
     final controllerProvider = BetterPlayerControllerProvider(
       controller: widget.controller,
-      child: _buildPlayer(),
+      child: _BetterPlayerVideoWithVisibility(controller: widget.controller),
     );
 
     final routePageBuilder = _betterPlayerConfiguration.routePageBuilder;
@@ -284,21 +272,26 @@ class _BetterPlayerState extends State<BetterPlayer>
     );
   }
 
-  Widget _buildPlayer() {
-    return VisibilityDetector(
-      key: Key('${widget.controller.hashCode}_key'),
-      onVisibilityChanged: (VisibilityInfo info) =>
-          widget.controller.onPlayerVisibilityChanged(info.visibleFraction),
-      child: BetterPlayerWithControls(
-        controller: widget.controller,
-      ),
-    );
-  }
-
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     widget.controller.setAppLifecycleState(state);
+  }
+}
+
+class _BetterPlayerVideoWithVisibility extends StatelessWidget {
+  final BetterPlayerController controller;
+
+  const _BetterPlayerVideoWithVisibility({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return VisibilityDetector(
+      key: Key('${controller.hashCode}_key'),
+      onVisibilityChanged: (VisibilityInfo info) =>
+          controller.onPlayerVisibilityChanged(info.visibleFraction),
+      child: BetterPlayerWithControls(controller: controller),
+    );
   }
 }
 

--- a/lib/src/core/better_player_full_screen_video.dart
+++ b/lib/src/core/better_player_full_screen_video.dart
@@ -1,0 +1,23 @@
+import 'package:better_player/better_player.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerFullScreenVideo extends StatelessWidget {
+  final BetterPlayerControllerProvider controllerProvider;
+
+  const BetterPlayerFullScreenVideo({
+    required this.controllerProvider,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: Container(
+        alignment: Alignment.center,
+        color: Colors.black,
+        child: controllerProvider,
+      ),
+    );
+  }
+}

--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -136,7 +136,8 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
       child: Stack(
         fit: StackFit.passthrough,
         children: <Widget>[
-          if (placeholderOnTop) _buildPlaceholder(betterPlayerController),
+          if (placeholderOnTop)
+            BetterPlayerPlaceholder(controller: betterPlayerController),
           Transform.rotate(
             angle: rotation * pi / 180,
             child: _BetterPlayerVideoFitWidget(
@@ -145,30 +146,60 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
             ),
           ),
           betterPlayerController.betterPlayerConfiguration.overlay ??
-              Container(),
+              const SizedBox(),
           BetterPlayerSubtitlesDrawer(
             betterPlayerController: betterPlayerController,
             betterPlayerSubtitlesConfiguration: subtitlesConfiguration,
             subtitles: betterPlayerController.subtitlesLines,
             playerVisibilityStream: playerVisibilityStreamController.stream,
           ),
-          if (!placeholderOnTop) _buildPlaceholder(betterPlayerController),
-          _buildControls(context, betterPlayerController),
+          if (!placeholderOnTop)
+            BetterPlayerPlaceholder(controller: betterPlayerController),
+          BetterPlayerControlsSelectionWidget(
+            controller: betterPlayerController,
+            onControlsVisibilityChanged: onControlsVisibilityChanged,
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildPlaceholder(BetterPlayerController betterPlayerController) {
-    return betterPlayerController.betterPlayerDataSource!.placeholder ??
-        betterPlayerController.betterPlayerConfiguration.placeholder ??
-        Container();
+  void onControlsVisibilityChanged(bool state) {
+    playerVisibilityStreamController.add(state);
   }
+}
 
-  Widget _buildControls(
-    BuildContext context,
-    BetterPlayerController betterPlayerController,
-  ) {
+///Widget which renders placeholder on top of the video.
+class BetterPlayerPlaceholder extends StatelessWidget {
+  const BetterPlayerPlaceholder({
+    required this.controller,
+    super.key,
+  });
+
+  final BetterPlayerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return controller.betterPlayerDataSource?.placeholder ??
+        controller.betterPlayerConfiguration.placeholder ??
+        const SizedBox();
+  }
+}
+
+///Widget which determines which controls should be used.
+class BetterPlayerControlsSelectionWidget extends StatelessWidget {
+  const BetterPlayerControlsSelectionWidget({
+    required this.controller,
+    required this.onControlsVisibilityChanged,
+    super.key,
+  });
+
+  final BetterPlayerController controller;
+  final Function(bool) onControlsVisibilityChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final controlsConfiguration = controller.betterPlayerControlsConfiguration;
     if (controlsConfiguration.showControls) {
       var playerTheme = controlsConfiguration.playerTheme;
       if (playerTheme == null) {
@@ -182,35 +213,23 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
       if (controlsConfiguration.customControlsBuilder != null &&
           playerTheme == BetterPlayerTheme.custom) {
         return controlsConfiguration.customControlsBuilder!(
-          betterPlayerController,
+          controller,
           onControlsVisibilityChanged,
         );
       } else if (playerTheme == BetterPlayerTheme.material) {
-        return _buildMaterialControl();
+        return BetterPlayerMaterialControls(
+          onControlsVisibilityChanged: onControlsVisibilityChanged,
+          controlsConfiguration: controlsConfiguration,
+        );
       } else if (playerTheme == BetterPlayerTheme.cupertino) {
-        return _buildCupertinoControl();
+        return BetterPlayerCupertinoControls(
+          onControlsVisibilityChanged: onControlsVisibilityChanged,
+          controlsConfiguration: controlsConfiguration,
+        );
       }
     }
 
     return const SizedBox();
-  }
-
-  Widget _buildMaterialControl() {
-    return BetterPlayerMaterialControls(
-      onControlsVisibilityChanged: onControlsVisibilityChanged,
-      controlsConfiguration: controlsConfiguration,
-    );
-  }
-
-  Widget _buildCupertinoControl() {
-    return BetterPlayerCupertinoControls(
-      onControlsVisibilityChanged: onControlsVisibilityChanged,
-      controlsConfiguration: controlsConfiguration,
-    );
-  }
-
-  void onControlsVisibilityChanged(bool state) {
-    playerVisibilityStreamController.add(state);
   }
 }
 

--- a/lib/src/subtitles/better_player_subtitles_drawer.dart
+++ b/lib/src/subtitles/better_player_subtitles_drawer.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/subtitles/better_player_subtitle.dart';
-import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:better_player/src/subtitles/better_player_subtitles_drawer_item.dart';
 import 'package:material_ui/material_ui.dart';
 
 class BetterPlayerSubtitlesDrawer extends StatefulWidget {
@@ -101,7 +101,14 @@ class _BetterPlayerSubtitlesDrawerState
     final subtitle = _getSubtitleAtCurrentPosition();
     widget.betterPlayerController.renderedSubtitle = subtitle;
     final subtitles = subtitle?.texts ?? [];
-    final textWidgets = subtitles.map(_buildSubtitleTextWidget).toList();
+    final textWidgets = subtitles.map((subtitleText) {
+      return BetterPlayerSubtitlesDrawerItem(
+        subtitleText: subtitleText,
+        configuration: _configuration!,
+        innerTextStyle: _innerTextStyle,
+        outerTextStyle: _outerTextStyle,
+      );
+    }).toList();
 
     return Container(
       height: double.infinity,
@@ -134,41 +141,6 @@ class _BetterPlayerSubtitlesDrawerState
       }
     }
     return null;
-  }
-
-  Widget _buildSubtitleTextWidget(String subtitleText) {
-    return Row(
-      children: [
-        Expanded(
-          child: Align(
-            alignment: _configuration!.alignment,
-            child: _getTextWithStroke(subtitleText),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _getTextWithStroke(String subtitleText) {
-    return ColoredBox(
-      color: _configuration!.backgroundColor,
-      child: Stack(
-        children: [
-          if (_configuration!.outlineEnabled)
-            _buildHtmlWidget(subtitleText, _outerTextStyle)
-          else
-            const SizedBox(),
-          _buildHtmlWidget(subtitleText, _innerTextStyle),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildHtmlWidget(String text, TextStyle textStyle) {
-    return HtmlWidget(
-      text,
-      textStyle: textStyle,
-    );
   }
 
   BetterPlayerSubtitlesConfiguration setupDefaultConfiguration() {

--- a/lib/src/subtitles/better_player_subtitles_drawer_item.dart
+++ b/lib/src/subtitles/better_player_subtitles_drawer_item.dart
@@ -1,0 +1,47 @@
+import 'package:better_player/src/subtitles/better_player_subtitles_configuration.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:material_ui/material_ui.dart';
+
+class BetterPlayerSubtitlesDrawerItem extends StatelessWidget {
+  final String subtitleText;
+  final BetterPlayerSubtitlesConfiguration configuration;
+  final TextStyle innerTextStyle;
+  final TextStyle outerTextStyle;
+
+  const BetterPlayerSubtitlesDrawerItem({
+    required this.subtitleText,
+    required this.configuration,
+    required this.innerTextStyle,
+    required this.outerTextStyle,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Align(
+            alignment: configuration.alignment,
+            child: _getTextWithStroke(subtitleText),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _getTextWithStroke(String subtitleText) {
+    return ColoredBox(
+      color: configuration.backgroundColor,
+      child: Stack(
+        children: [
+          if (configuration.outlineEnabled)
+            HtmlWidget(subtitleText, textStyle: outerTextStyle)
+          else
+            const SizedBox(),
+          HtmlWidget(subtitleText, textStyle: innerTextStyle),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_player
 description: Advanced video player. It solves many typical use cases and it's easy to run.
-version: 0.4.3
+version: 0.5.0
 homepage: https://github.com/jhomlala/betterplayer
 documentation: https://jhomlala.github.io/betterplayer/
 

--- a/test/controls/better_player_cupertino_bottom_bar_test.dart
+++ b/test/controls/better_player_cupertino_bottom_bar_test.dart
@@ -1,0 +1,134 @@
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/controls/better_player_cupertino_bottom_bar.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../helpers/better_player_mock_controller.dart';
+import '../helpers/better_player_test_utils.dart';
+import '../helpers/mock_method_channel.dart';
+import '../helpers/mock_video_player_controller.dart';
+
+void main() {
+  late BetterPlayerMockController mockController;
+  late MockVideoPlayerController mockVideoPlayerController;
+
+  setUp(() async {
+    final mockMethodChannel = MockMethodChannel();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          mockMethodChannel.channel,
+          mockMethodChannel.handle,
+        );
+
+    mockVideoPlayerController = MockVideoPlayerController();
+    mockController = BetterPlayerMockController(
+      const BetterPlayerConfiguration(),
+    );
+    mockController.videoPlayerController = mockVideoPlayerController;
+    await mockController.setupDataSource(
+      BetterPlayerDataSource.network(BetterPlayerTestUtils.forBiggerBlazesUrl),
+    );
+  });
+
+  Widget wrapWidget(Widget widget) {
+    return MaterialApp(
+      home: Scaffold(
+        body: widget,
+      ),
+    );
+  }
+
+  testWidgets('Cupertino bottom bar shows play button when paused', (
+    WidgetTester tester,
+  ) async {
+    final controlsConfiguration = BetterPlayerControlsConfiguration.cupertino();
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerCupertinoBottomBar(
+          controller: mockController,
+          controlsConfiguration: controlsConfiguration,
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {},
+          onSkipBack: () {},
+          onSkipForward: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          barHeight: 40,
+          marginSize: 5,
+          backgroundColor: Colors.black,
+          iconColor: Colors.white,
+          latestValue: VideoPlayerValue(duration: const Duration(seconds: 10)),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(controlsConfiguration.playIcon), findsOneWidget);
+  });
+
+  testWidgets('Cupertino bottom bar shows pause button when playing', (
+    WidgetTester tester,
+  ) async {
+    final controlsConfiguration = BetterPlayerControlsConfiguration.cupertino();
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerCupertinoBottomBar(
+          controller: mockController,
+          controlsConfiguration: controlsConfiguration,
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {},
+          onSkipBack: () {},
+          onSkipForward: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          barHeight: 40,
+          marginSize: 5,
+          backgroundColor: Colors.black,
+          iconColor: Colors.white,
+          latestValue: VideoPlayerValue(
+            duration: const Duration(seconds: 10),
+            isPlaying: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(controlsConfiguration.pauseIcon), findsOneWidget);
+  });
+
+  testWidgets('Cupertino bottom bar triggers onPlayPause callback', (
+    WidgetTester tester,
+  ) async {
+    var playPauseTriggered = false;
+    final controlsConfiguration = BetterPlayerControlsConfiguration.cupertino();
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerCupertinoBottomBar(
+          controller: mockController,
+          controlsConfiguration: controlsConfiguration,
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {
+            playPauseTriggered = true;
+          },
+          onSkipBack: () {},
+          onSkipForward: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          barHeight: 40,
+          marginSize: 5,
+          backgroundColor: Colors.black,
+          iconColor: Colors.white,
+          latestValue: VideoPlayerValue(duration: const Duration(seconds: 10)),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(controlsConfiguration.playIcon));
+    expect(playPauseTriggered, isTrue);
+  });
+}

--- a/test/controls/better_player_material_bottom_bar_test.dart
+++ b/test/controls/better_player_material_bottom_bar_test.dart
@@ -1,0 +1,150 @@
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/controls/better_player_material_bottom_bar.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../helpers/better_player_mock_controller.dart';
+import '../helpers/better_player_test_utils.dart';
+import '../helpers/mock_method_channel.dart';
+import '../helpers/mock_video_player_controller.dart';
+
+void main() {
+  late BetterPlayerMockController mockController;
+  late MockVideoPlayerController mockVideoPlayerController;
+
+  setUp(() async {
+    final mockMethodChannel = MockMethodChannel();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          mockMethodChannel.channel,
+          mockMethodChannel.handle,
+        );
+
+    mockVideoPlayerController = MockVideoPlayerController();
+    mockController = BetterPlayerMockController(
+      const BetterPlayerConfiguration(),
+    );
+    mockController.videoPlayerController = mockVideoPlayerController;
+    await mockController.setupDataSource(
+      BetterPlayerDataSource.network(BetterPlayerTestUtils.forBiggerBlazesUrl),
+    );
+  });
+
+  Widget wrapWidget(Widget widget) {
+    return MaterialApp(
+      home: Scaffold(
+        body: widget,
+      ),
+    );
+  }
+
+  testWidgets('Material bottom bar shows play button when paused', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialBottomBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {},
+          onMute: () {},
+          onExpandCollapse: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          latestValue: VideoPlayerValue(duration: const Duration(seconds: 10)),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.play_arrow_outlined), findsOneWidget);
+  });
+
+  testWidgets('Material bottom bar shows pause button when playing', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialBottomBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {},
+          onMute: () {},
+          onExpandCollapse: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          latestValue: VideoPlayerValue(
+            duration: const Duration(seconds: 10),
+            isPlaying: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.pause_outlined), findsOneWidget);
+  });
+
+  testWidgets('Material bottom bar triggers onPlayPause callback', (
+    WidgetTester tester,
+  ) async {
+    var playPauseTriggered = false;
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialBottomBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {
+            playPauseTriggered = true;
+          },
+          onMute: () {},
+          onExpandCollapse: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          latestValue: VideoPlayerValue(duration: const Duration(seconds: 10)),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(
+        const Key('better_player_material_controls_play_pause_button'),
+      ),
+    );
+    expect(playPauseTriggered, isTrue);
+  });
+
+  testWidgets('Material bottom bar shows mute icon when volume is 0', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialBottomBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onPlayPause: () {},
+          onMute: () {},
+          onExpandCollapse: () {},
+          onProgressBarDragStart: () {},
+          onProgressBarDragEnd: () {},
+          onProgressBarTapDown: () {},
+          latestValue: VideoPlayerValue(
+            duration: const Duration(seconds: 10),
+            volume: 0,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.volume_off_outlined), findsOneWidget);
+  });
+}

--- a/test/controls/better_player_material_top_bar_test.dart
+++ b/test/controls/better_player_material_top_bar_test.dart
@@ -1,0 +1,95 @@
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/controls/better_player_material_top_bar.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../helpers/better_player_mock_controller.dart';
+import '../helpers/mock_method_channel.dart';
+
+void main() {
+  late BetterPlayerMockController mockController;
+
+  setUp(() {
+    final mockMethodChannel = MockMethodChannel();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          mockMethodChannel.channel,
+          mockMethodChannel.handle,
+        );
+
+    mockController = BetterPlayerMockController(
+      const BetterPlayerConfiguration(),
+    );
+  });
+
+  Widget wrapWidget(Widget widget) {
+    return MaterialApp(
+      home: Scaffold(
+        body: widget,
+      ),
+    );
+  }
+
+  testWidgets('Material top bar shows more button', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialTopBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onShowMoreClicked: () {},
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.more_vert_outlined), findsOneWidget);
+  });
+
+  testWidgets('Material top bar triggers onShowMoreClicked', (
+    WidgetTester tester,
+  ) async {
+    var showMoreTriggered = false;
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialTopBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onShowMoreClicked: () {
+            showMoreTriggered = true;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert_outlined));
+    expect(showMoreTriggered, isTrue);
+  });
+
+  testWidgets('Material top bar shows PiP button when enabled and supported', (
+    WidgetTester tester,
+  ) async {
+    // Note: BetterPlayerController.isPictureInPictureSupported() is hardcoded
+    // to return false in some environments or based on platform.
+    // However, the widget uses it.
+
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerMaterialTopBar(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          controlsNotVisible: false,
+          onPlayerHide: () {},
+          onShowMoreClicked: () {},
+        ),
+      ),
+    );
+
+    // By default it might not show because GlobalKey is null in mockController
+    expect(find.byIcon(Icons.picture_in_picture_outlined), findsNothing);
+  });
+}

--- a/test/controls/better_player_overflow_menu_test.dart
+++ b/test/controls/better_player_overflow_menu_test.dart
@@ -1,0 +1,158 @@
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/controls/better_player_overflow_menu.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../helpers/better_player_mock_controller.dart';
+import '../helpers/mock_method_channel.dart';
+
+void main() {
+  late BetterPlayerMockController mockController;
+
+  setUp(() {
+    final mockMethodChannel = MockMethodChannel();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          mockMethodChannel.channel,
+          mockMethodChannel.handle,
+        );
+
+    mockController = BetterPlayerMockController(
+      const BetterPlayerConfiguration(),
+    );
+  });
+
+  Widget wrapWidget(Widget widget) {
+    return MaterialApp(
+      home: Scaffold(
+        body: widget,
+      ),
+    );
+  }
+
+  testWidgets('Overflow menu shows all items when enabled', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerOverflowMenu(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          onPlaybackSpeedClicked: () {},
+          onSubtitlesClicked: () {},
+          onQualitiesClicked: () {},
+          onAudioTracksClicked: () {},
+        ),
+      ),
+    );
+
+    expect(
+      find.text(mockController.translations.overflowMenuPlaybackSpeed),
+      findsOneWidget,
+    );
+    expect(
+      find.text(mockController.translations.overflowMenuSubtitles),
+      findsOneWidget,
+    );
+    expect(
+      find.text(mockController.translations.overflowMenuQuality),
+      findsOneWidget,
+    );
+    expect(
+      find.text(mockController.translations.overflowMenuAudioTracks),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('Overflow menu hides items when disabled', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerOverflowMenu(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(
+            enablePlaybackSpeed: false,
+            enableSubtitles: false,
+            enableQualities: false,
+            enableAudioTracks: false,
+          ),
+          onPlaybackSpeedClicked: () {},
+          onSubtitlesClicked: () {},
+          onQualitiesClicked: () {},
+          onAudioTracksClicked: () {},
+        ),
+      ),
+    );
+
+    expect(
+      find.text(mockController.translations.overflowMenuPlaybackSpeed),
+      findsNothing,
+    );
+    expect(
+      find.text(mockController.translations.overflowMenuSubtitles),
+      findsNothing,
+    );
+    expect(
+      find.text(mockController.translations.overflowMenuQuality),
+      findsNothing,
+    );
+    expect(
+      find.text(mockController.translations.overflowMenuAudioTracks),
+      findsNothing,
+    );
+  });
+
+  testWidgets('Overflow menu triggers callbacks', (WidgetTester tester) async {
+    var speedTriggered = false;
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerOverflowMenu(
+          controller: mockController,
+          controlsConfiguration: const BetterPlayerControlsConfiguration(),
+          onPlaybackSpeedClicked: () {
+            speedTriggered = true;
+          },
+          onSubtitlesClicked: () {},
+          onQualitiesClicked: () {},
+          onAudioTracksClicked: () {},
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.text(mockController.translations.overflowMenuPlaybackSpeed),
+    );
+    expect(speedTriggered, isTrue);
+  });
+
+  testWidgets('Overflow menu shows custom items', (WidgetTester tester) async {
+    var customTriggered = false;
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerOverflowMenu(
+          controller: mockController,
+          controlsConfiguration: BetterPlayerControlsConfiguration(
+            overflowMenuCustomItems: [
+              BetterPlayerOverflowMenuItem(
+                Icons.star,
+                'Custom Item',
+                () {
+                  customTriggered = true;
+                },
+              ),
+            ],
+          ),
+          onPlaybackSpeedClicked: () {},
+          onSubtitlesClicked: () {},
+          onQualitiesClicked: () {},
+          onAudioTracksClicked: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('Custom Item'), findsOneWidget);
+    await tester.tap(find.text('Custom Item'));
+    expect(customTriggered, isTrue);
+  });
+}

--- a/test/core/better_player_placeholder_test.dart
+++ b/test/core/better_player_placeholder_test.dart
@@ -1,0 +1,81 @@
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/core/better_player_with_controls.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../helpers/better_player_mock_controller.dart';
+import '../helpers/mock_method_channel.dart';
+
+void main() {
+  late BetterPlayerMockController mockController;
+
+  setUp(() {
+    final mockMethodChannel = MockMethodChannel();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          mockMethodChannel.channel,
+          mockMethodChannel.handle,
+        );
+
+    mockController = BetterPlayerMockController(
+      const BetterPlayerConfiguration(),
+    );
+  });
+
+  Widget wrapWidget(Widget widget) {
+    return MaterialApp(
+      home: Scaffold(
+        body: widget,
+      ),
+    );
+  }
+
+  testWidgets('Placeholder shows widget from data source', (
+    WidgetTester tester,
+  ) async {
+    const placeholder = Text('DataSource Placeholder');
+    mockController.setupDataSource(
+      BetterPlayerDataSource.network(
+        'url',
+        placeholder: placeholder,
+      ),
+    );
+
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerPlaceholder(controller: mockController),
+      ),
+    );
+
+    expect(find.text('DataSource Placeholder'), findsOneWidget);
+  });
+
+  testWidgets('Placeholder shows widget from configuration as fallback', (
+    WidgetTester tester,
+  ) async {
+    const placeholder = Text('Config Placeholder');
+    final controller = BetterPlayerMockController(
+      const BetterPlayerConfiguration(placeholder: placeholder),
+    );
+
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerPlaceholder(controller: controller),
+      ),
+    );
+
+    expect(find.text('Config Placeholder'), findsOneWidget);
+  });
+
+  testWidgets('Placeholder shows nothing when not provided', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        BetterPlayerPlaceholder(controller: mockController),
+      ),
+    );
+
+    expect(find.byType(SizedBox), findsOneWidget);
+  });
+}

--- a/test/subtitles/better_player_subtitles_drawer_item_test.dart
+++ b/test/subtitles/better_player_subtitles_drawer_item_test.dart
@@ -1,0 +1,51 @@
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/subtitles/better_player_subtitles_drawer_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  Widget wrapWidget(Widget widget) {
+    return MaterialApp(
+      home: Scaffold(
+        body: widget,
+      ),
+    );
+  }
+
+  testWidgets('Subtitles drawer item renders text', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWidget(
+        const BetterPlayerSubtitlesDrawerItem(
+          subtitleText: 'Test Subtitle',
+          configuration: BetterPlayerSubtitlesConfiguration(
+            outlineEnabled: false,
+          ),
+          innerTextStyle: TextStyle(),
+          outerTextStyle: TextStyle(),
+        ),
+      ),
+    );
+
+    expect(find.text('Test Subtitle', findRichText: true), findsOneWidget);
+  });
+
+  testWidgets(
+    'Subtitles drawer item renders HTML text twice when outline enabled',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrapWidget(
+          const BetterPlayerSubtitlesDrawerItem(
+            subtitleText: '<b>HTML</b> Subtitle',
+            configuration: BetterPlayerSubtitlesConfiguration(),
+            innerTextStyle: TextStyle(),
+            outerTextStyle: TextStyle(),
+          ),
+        ),
+      );
+
+      expect(find.text('HTML Subtitle', findRichText: true), findsNWidgets(2));
+    },
+  );
+}


### PR DESCRIPTION
* Updated: Major architectural refactor of player controls and UI components. Helper build methods (`_buildWidget()`) were replaced with dedicated Flutter `Widget` classes for improved modularity, performance, and maintainability.
* Added: New granular widgets for Material and Cupertino controls, including top/bottom bars, hit areas, and status overlays.
* Updated: Applied project-wide coding standard for named parameters (required for 2+ arguments or 1 boolean argument).
