### PR TITLE
fix: DASH live stream sliding window looping issue on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Fixed: Video container does not resize when resolution changes dynamically (e.g., in DASH/HLS adaptive streams). Added `changedSize` event for both Android and iOS to update player dimensions during playback.
+* Fixed: DASH live streams with sliding windows jumping or looping back on Android. Improved native DASH live configuration and correctly marked example streams as live.
 
 ## 0.6.1
 * Added: Example demonstrating auto-fullscreen on rotation using `OrientationBuilder`.
@@ -554,7 +555,7 @@ setBetterPlayerGlobalKey.
 
 ## 0.0.23
 * General bug fixes.
-* Added playerVisibilityChangedBehavior in BetterPlayerConfiguration.
+* Added player visibility changed behavior in BetterPlayerConfiguration.
 * Changed player behavior when player is not visible in viewport: if player was playing before leaving viewport it will be paused and if user views player again it will start playing automatically.
 * Added BetterPlayer.network and BetterPlayer.file methods.
 * Changed iOS & Android native classes name to prevent conflict issues with video_player.

--- a/android/src/main/kotlin/pl/hasoft/better_player/BetterPlayer.kt
+++ b/android/src/main/kotlin/pl/hasoft/better_player/BetterPlayer.kt
@@ -343,6 +343,11 @@ internal class BetterPlayer(
         if (cacheKey != null && cacheKey.isNotEmpty()) {
             mediaItemBuilder.setCustomCacheKey(cacheKey)
         }
+        mediaItemBuilder.setLiveConfiguration(
+            MediaItem.LiveConfiguration.Builder()
+                .setTargetOffsetMs(30000)
+                .build()
+        )
         val mediaItem = mediaItemBuilder.build()
         var drmSessionManagerProvider: DrmSessionManagerProvider = DefaultDrmSessionManagerProvider()
         drmSessionManager?.let { drmSessionManager ->

--- a/example/lib/pages/dash_page.dart
+++ b/example/lib/pages/dash_page.dart
@@ -19,11 +19,13 @@ class _DashPageState extends State<DashPage> {
       aspectRatio: 16 / 9,
       fit: BoxFit.contain,
     );
+
     _betterPlayerController = BetterPlayerController(betterPlayerConfiguration);
     _betterPlayerController.setupDataSource(
       BetterPlayerDataSource(
         BetterPlayerDataSourceType.network,
         Constants.dashStreamUrl,
+        liveStream: true,
       ),
     );
 


### PR DESCRIPTION
• Fixed: DASH live streams with sliding windows jumping or looping back on Android. Improved native DASH live configuration and correctly marked example streams as live.