### PR TITLE
Fix: Handle DASH streams on iOS with descriptive error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+* Fixed: Improved error handling for DASH streams on iOS by providing a descriptive Dart-side exception instead of a generic native error (AVPlayer does not support DASH).
+* Updated: Documentation to clarify that DASH and Smooth Streaming are currently Android-only features.
 * Fixed: Video container does not resize when resolution changes dynamically (e.g., in DASH/HLS adaptive streams). Added `changedSize` event for both Android and iOS to update player dimensions during playback.
 * Fixed: DASH live streams with sliding windows jumping or looping back on Android. Improved native DASH live configuration and correctly marked example streams as live.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Better Player is a powerful video player for Flutter, built on top of the offici
 ## 🚀 Key Features
 
 ### 🎬 Advanced Playback
-* **Adaptive Streaming**: Full support for **HLS**, **DASH**, and **Smooth Streaming** with track selection.
+* **Adaptive Streaming**: Full support for **HLS** (Android & iOS), **DASH** (Android), and **Smooth Streaming** (Android) with track selection.
 * **Resolution Control**: Easy switching between alternative video resolutions.
 * **Smart Caching**: Seamlessly cache videos for high-performance offline playback.
 * **Customizable UI**: Refactored controls that are highly customizable via configuration.

--- a/docs/migration_from_video_player.md
+++ b/docs/migration_from_video_player.md
@@ -180,5 +180,5 @@ Now that you are using `better_player`, you can easily enable advanced features 
   );
   ```
 - **Subtitles**: Add SRT or WebVTT subtitles effortlessly via `BetterPlayerSubtitlesSource`.
-- **HLS / DASH Adaptive Streaming**: Pass adaptive streaming URLs directly into `BetterPlayerDataSourceType.network`.
+- **HLS / DASH Adaptive Streaming**: Pass adaptive streaming URLs directly into `BetterPlayerDataSourceType.network`. Note: DASH is currently only supported on Android.
 - **Picture-in-Picture (PiP)**: Enable PiP support with built-in controls and state listeners.

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -8,6 +8,7 @@ import 'package:better_player/src/subtitles/better_player_subtitles_factory.dart
 import 'package:better_player/src/video_player/video_player.dart';
 import 'package:better_player/src/video_player/video_player_platform_interface.dart';
 import 'package:collection/collection.dart' show IterableExtension;
+import 'package:flutter/foundation.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -241,6 +242,23 @@ class BetterPlayerController {
         },
       ),
     );
+
+    if (defaultTargetPlatform == TargetPlatform.iOS &&
+        (BetterPlayerAsmsUtils.isDataSourceDash(betterPlayerDataSource.url) ||
+            betterPlayerDataSource.videoFormat ==
+                BetterPlayerVideoFormat.dash)) {
+      _postEvent(
+        BetterPlayerEvent(
+          BetterPlayerEventType.exception,
+          parameters: <String, dynamic>{
+            'exception':
+                'DASH streams are not supported on iOS platform. Please use HLS instead.',
+          },
+        ),
+      );
+      return;
+    }
+
     _postControllerEvent(BetterPlayerControllerEvent.setupDataSource);
     _hasCurrentDataSourceStarted = false;
     _hasCurrentDataSourceInitialized = false;

--- a/test/core/better_player_controller_test.dart
+++ b/test/core/better_player_controller_test.dart
@@ -1,5 +1,6 @@
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/configuration/better_player_controller_event.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -904,6 +905,36 @@ void main() {
           events.contains(BetterPlayerControllerEvent.hideFullscreen),
           true,
         );
+      });
+
+      test('setupDataSource emits exception for DASH on iOS', () async {
+        final previousPlatform = debugDefaultTargetPlatformOverride;
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          final controller = BetterPlayerMockController(
+            const BetterPlayerConfiguration(),
+          );
+          BetterPlayerEvent? exceptionEvent;
+          controller.addEventsListener((event) {
+            if (event.betterPlayerEventType ==
+                BetterPlayerEventType.exception) {
+              exceptionEvent = event;
+            }
+          });
+
+          await controller.setupDataSource(
+            BetterPlayerDataSource.network('https://example.com/video.mpd'),
+          );
+
+          expect(exceptionEvent != null, true);
+          expect(
+            exceptionEvent?.parameters?['exception'],
+            'DASH streams are not supported on iOS platform. Please use HLS instead.',
+          );
+          expect(controller.videoPlayerController, null);
+        } finally {
+          debugDefaultTargetPlatformOverride = previousPlatform;
+        }
       });
 
       testWidgets('BetterPlayerController.of(context) works', (


### PR DESCRIPTION
• Fixed: Improved error handling for DASH streams on iOS by providing a descriptive Dart-side exception instead of a generic native error (AVPlayer does not support DASH).