### PR TITLE
fix: embedded HLS subtitles rendering by correcting segment timing and JIT loading logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Fixed: Embedded HLS/ASMS subtitles not being rendered due to incorrect segment timing and JIT loading logic.
+
 ## 0.7.0
 * Fixed: Improved error handling for DASH streams on iOS by providing a descriptive Dart-side exception instead of a generic native error (AVPlayer does not support DASH).
 * Updated: Documentation to clarify that DASH and Smooth Streaming are currently Android-only features.

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -418,8 +418,8 @@ class BetterPlayerController {
 
       final segmentsToLoad = _betterPlayerSubtitlesSource?.asmsSegments
           ?.where((segment) {
-            return segment.startTime > position &&
-                segment.endTime < loadDurationEnd &&
+            return segment.endTime > position &&
+                segment.startTime < loadDurationEnd &&
                 !_asmsSegmentsLoaded.contains(segment.realUrl);
           })
           .map((segment) => segment.realUrl)

--- a/lib/src/hls/better_player_hls_utils.dart
+++ b/lib/src/hls/better_player_hls_utils.dart
@@ -148,7 +148,6 @@ class BetterPlayerHlsUtils {
         if (isSegmented) {
           final nextMicroSecondsFromStart =
               microSecondsFromStart + segment.durationUs!;
-          microSecondsFromStart = nextMicroSecondsFromStart;
           asmsSegments.add(
             BetterPlayerAsmsSubtitleSegment(
               Duration(microseconds: microSecondsFromStart),
@@ -156,6 +155,7 @@ class BetterPlayerHlsUtils {
               realUrl,
             ),
           );
+          microSecondsFromStart = nextMicroSecondsFromStart;
         }
       }
 

--- a/test/hls/better_player_hls_utils_test.dart
+++ b/test/hls/better_player_hls_utils_test.dart
@@ -48,6 +48,8 @@ class MockHttpClientResponse extends StreamView<List<int>>
 #EXT-X-TARGETDURATION:10
 #EXTINF:10.0,
 segment1.vtt
+#EXTINF:10.0,
+segment2.vtt
 '''),
         ),
       );
@@ -129,6 +131,21 @@ video.m3u8
 
           expect(subtitles.length, 1);
           expect(subtitles[0].name, 'English');
+          expect(subtitles[0].isSegmented, true);
+          expect(subtitles[0].segments?.length, 2);
+          expect(subtitles[0].segments?[0].startTime, Duration.zero);
+          expect(
+            subtitles[0].segments?[0].endTime,
+            const Duration(seconds: 10),
+          );
+          expect(
+            subtitles[0].segments?[1].startTime,
+            const Duration(seconds: 10),
+          );
+          expect(
+            subtitles[0].segments?[1].endTime,
+            const Duration(seconds: 20),
+          );
         },
         TestHttpOverrides(),
       );


### PR DESCRIPTION
* Fixed: Embedded HLS/ASMS subtitles not being rendered due to incorrect segment timing and JIT loading logic.