### PR TITLE
fix: resolve race condition in audio track initialization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Fixed: Audio tracks returning null immediately after data source setup by awaiting ASMS parsing and improving track state management.
 * Fixed: Embedded HLS/ASMS subtitles not being rendered due to incorrect segment timing and JIT loading logic.
 
 ## 0.7.0

--- a/lib/src/controls/better_player_controls_state.dart
+++ b/lib/src/controls/better_player_controls_state.dart
@@ -269,7 +269,7 @@ abstract class BetterPlayerControlsState<T extends StatefulWidget>
     final children = <Widget>[];
     final selectedAsmsAudioTrack =
         betterPlayerController!.betterPlayerAsmsAudioTrack;
-    if (asmsTracks != null) {
+    if (asmsTracks.isNotEmpty) {
       for (var index = 0; index < asmsTracks.length; index++) {
         final isSelected =
             selectedAsmsAudioTrack != null &&

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -286,17 +286,14 @@ class BetterPlayerController {
       );
     }
 
-    Future? asmsFuture;
+    final setupFutures = <Future<dynamic>>[
+      _setupDataSource(betterPlayerDataSource),
+    ];
     if (_isDataSourceAsms(betterPlayerDataSource)) {
-      asmsFuture = _setupAsmsDataSource(betterPlayerDataSource);
+      setupFutures.add(_setupAsmsDataSource(betterPlayerDataSource));
     }
+    await Future.wait(setupFutures);
 
-    ///Process data source
-    await _setupDataSource(betterPlayerDataSource);
-
-    if (asmsFuture != null) {
-      await asmsFuture;
-    }
     _setupSubtitles();
     setTrack(BetterPlayerAsmsTrack.defaultTrack());
   }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -175,10 +175,10 @@ class BetterPlayerController {
   bool get controlsAlwaysVisible => _controlsAlwaysVisible;
 
   ///List of all possible audio tracks returned from ASMS stream
-  List<BetterPlayerAsmsAudioTrack>? _betterPlayerAsmsAudioTracks;
+  List<BetterPlayerAsmsAudioTrack> _betterPlayerAsmsAudioTracks = [];
 
   ///List of all possible audio tracks returned from ASMS stream
-  List<BetterPlayerAsmsAudioTrack>? get betterPlayerAsmsAudioTracks =>
+  List<BetterPlayerAsmsAudioTrack> get betterPlayerAsmsAudioTracks =>
       _betterPlayerAsmsAudioTracks;
 
   ///Selected ASMS audio track
@@ -275,6 +275,8 @@ class BetterPlayerController {
 
     ///Clear asms tracks
     betterPlayerAsmsTracks.clear();
+    _betterPlayerAsmsAudioTracks.clear();
+    _betterPlayerAsmsAudioTrack = null;
 
     ///Setup subtitles
     final betterPlayerSubtitlesSourceList = betterPlayerDataSource.subtitles;
@@ -284,16 +286,18 @@ class BetterPlayerController {
       );
     }
 
+    Future? asmsFuture;
     if (_isDataSourceAsms(betterPlayerDataSource)) {
-      _setupAsmsDataSource(betterPlayerDataSource).then((dynamic value) {
-        _setupSubtitles();
-      });
-    } else {
-      _setupSubtitles();
+      asmsFuture = _setupAsmsDataSource(betterPlayerDataSource);
     }
 
     ///Process data source
     await _setupDataSource(betterPlayerDataSource);
+
+    if (asmsFuture != null) {
+      await asmsFuture;
+    }
+    _setupSubtitles();
     setTrack(BetterPlayerAsmsTrack.defaultTrack());
   }
 
@@ -323,7 +327,7 @@ class BetterPlayerController {
   ///Configure HLS / DASH data source based on provided data source and configuration.
   ///This method configures tracks, subtitles and audio tracks from given
   ///master playlist.
-  Future _setupAsmsDataSource(BetterPlayerDataSource source) async {
+  Future<void> _setupAsmsDataSource(BetterPlayerDataSource source) async {
     final data = await BetterPlayerAsmsUtils.getDataFromUrl(
       betterPlayerDataSource!.url,
       _getHeaders(),
@@ -361,8 +365,8 @@ class BetterPlayerController {
       if (betterPlayerDataSource?.useAsmsAudioTracks == true &&
           _isDataSourceAsms(betterPlayerDataSource!)) {
         _betterPlayerAsmsAudioTracks = response.audios ?? [];
-        if (_betterPlayerAsmsAudioTracks?.isNotEmpty == true) {
-          setAudioTrack(_betterPlayerAsmsAudioTracks!.first);
+        if (_betterPlayerAsmsAudioTracks.isNotEmpty) {
+          setAudioTrack(_betterPlayerAsmsAudioTracks.first);
         }
       }
     }

--- a/lib/src/hls/better_player_hls_utils.dart
+++ b/lib/src/hls/better_player_hls_utils.dart
@@ -206,7 +206,7 @@ class BetterPlayerHlsUtils {
             id: index,
             label: audio.name,
             language: audio.format.language,
-            url: audio.url.toString(),
+            url: audio.url?.toString(),
           ),
         );
       }


### PR DESCRIPTION
• Fixed: Audio tracks returning null immediately after data source setup by awaiting ASMS parsing and improving track state management.