### PR TITLE
fix: HLS ABR sizing issue on Android TV by making UI reactive to size change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@
   - **Criticality**: What is the impact if this is not fixed or implemented?
   - **Surgical Nature**: How does this change minimize boilerplate and reuse existing code?
 - **Reproduction & Verification**: ALWAYS provide a reproducible data source (e.g., a specific URL or asset) so the reviewer can check the solution. For features, provide a clear example demonstrating the new functionality.
-- **Testing**: Every bug fix or new feature MUST include appropriate Dart tests. Do not add tests for the native part.
+- **Testing**: Every bug fix or new feature MUST include appropriate Dart tests. Do not add tests for the native part. When dealing with core player state changes, ensure tests verify UI reactivity (e.g., aspect ratio or layout updates when video size changes).
 - **Verification**: In every PR or implementation plan, include clear steps to verify the solution.
 
 ## Changelog Guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Fixed: HLS ABR video sizing issues (small video in corner) on Android TV and other platforms by making UI components reactive to resolution changes reported by the native layer.
 * Fixed: Broken image links in the documentation by updating the paths to `assets/media/`.
 * Fixed: Audio tracks returning null immediately after data source setup by awaiting ASMS parsing and improving track state management.
 * Fixed: Embedded HLS/ASMS subtitles not being rendered due to incorrect segment timing and JIT loading logic.

--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -38,8 +38,7 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
   @override
   void initState() {
     playerVisibilityStreamController.add(true);
-    _controllerEventSubscription = widget.controller!.controllerEventStream
-        .listen(_onControllerChanged);
+    _setupControllerEventSubscription();
     _setupVideoPlayerControllerListener();
     super.initState();
   }
@@ -47,14 +46,21 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
   @override
   void didUpdateWidget(BetterPlayerWithControls oldWidget) {
     if (oldWidget.controller != widget.controller) {
-      _controllerEventSubscription?.cancel();
-      _controllerEventSubscription = widget.controller!.controllerEventStream
-          .listen(_onControllerChanged);
+      _setupControllerEventSubscription();
       _setupVideoPlayerControllerListener();
     }
     super.didUpdateWidget(oldWidget);
   }
 
+  void _setupControllerEventSubscription() {
+    _controllerEventSubscription?.cancel();
+    _controllerEventSubscription = widget.controller!.controllerEventStream
+        .listen(_onControllerChanged);
+  }
+
+  /// Sets up a listener for the [VideoPlayerController].
+  /// This is required to react to resolution changes (HLS ABR) and update
+  /// the aspect ratio of the player (Issue #768).
   void _setupVideoPlayerControllerListener() {
     if (_videoPlayerController != widget.controller!.videoPlayerController) {
       _videoPlayerController?.removeListener(_onVideoPlayerChanged);
@@ -94,20 +100,15 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
 
     double? aspectRatio;
     if (betterPlayerController.isFullScreen) {
-      if (betterPlayerController
-              .betterPlayerConfiguration
-              .autoDetectFullscreenDeviceOrientation ||
-          betterPlayerController
-              .betterPlayerConfiguration
-              .autoDetectFullscreenAspectRatio) {
+      final config = betterPlayerController.betterPlayerConfiguration;
+      if (config.autoDetectFullscreenDeviceOrientation ||
+          config.autoDetectFullscreenAspectRatio) {
         aspectRatio =
             betterPlayerController.videoPlayerController?.value.aspectRatio ??
             1.0;
       } else {
         aspectRatio =
-            betterPlayerController
-                .betterPlayerConfiguration
-                .fullScreenAspectRatio ??
+            config.fullScreenAspectRatio ??
             BetterPlayerUtils.calculateAspectRatio(context);
       }
     } else {
@@ -282,15 +283,7 @@ class _BetterPlayerVideoFitWidgetState
   @override
   void initState() {
     super.initState();
-    if (!widget
-        .betterPlayerController
-        .betterPlayerConfiguration
-        .showPlaceholderUntilPlay) {
-      _started = true;
-    } else {
-      _started = widget.betterPlayerController.hasCurrentDataSourceStarted;
-    }
-
+    _updateStartedFlag();
     _initialized = controller?.value.initialized ?? false;
     _setupControllerEventSubscription();
     _setupVideoPlayerControllerListener();
@@ -298,11 +291,20 @@ class _BetterPlayerVideoFitWidgetState
 
   @override
   void didUpdateWidget(_BetterPlayerVideoFitWidget oldWidget) {
-    super.didUpdateWidget(oldWidget);
     if (oldWidget.betterPlayerController != widget.betterPlayerController) {
       _setupControllerEventSubscription();
     }
     _setupVideoPlayerControllerListener();
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void _updateStartedFlag() {
+    final config = widget.betterPlayerController.betterPlayerConfiguration;
+    if (!config.showPlaceholderUntilPlay) {
+      _started = true;
+    } else {
+      _started = widget.betterPlayerController.hasCurrentDataSourceStarted;
+    }
   }
 
   void _setupControllerEventSubscription() {
@@ -310,25 +312,31 @@ class _BetterPlayerVideoFitWidgetState
     _controllerEventSubscription = widget
         .betterPlayerController
         .controllerEventStream
-        .listen((event) {
-          if (event == BetterPlayerControllerEvent.play) {
-            if (!_started) {
-              setState(() {
-                _started =
-                    widget.betterPlayerController.hasCurrentDataSourceStarted;
-              });
-            }
-          }
-          if (event == BetterPlayerControllerEvent.setupDataSource) {
-            setState(() {
-              _started = false;
-              _initialized = false;
-              _setupVideoPlayerControllerListener();
-            });
-          }
-        });
+        .listen(_onControllerEvent);
   }
 
+  void _onControllerEvent(BetterPlayerControllerEvent event) {
+    switch (event) {
+      case BetterPlayerControllerEvent.play:
+        if (!_started) {
+          setState(() {
+            _updateStartedFlag();
+          });
+        }
+      case BetterPlayerControllerEvent.setupDataSource:
+        setState(() {
+          _started = false;
+          _initialized = false;
+          _setupVideoPlayerControllerListener();
+        });
+      default:
+        break;
+    }
+  }
+
+  /// Sets up a listener for the [VideoPlayerController].
+  /// This is required to react to resolution changes (HLS ABR) and update
+  /// the video dimensions inside FittedBox (Issue #768).
   void _setupVideoPlayerControllerListener() {
     if (_videoPlayerController != controller) {
       _videoPlayerController?.removeListener(_onVideoPlayerChanged);
@@ -341,9 +349,10 @@ class _BetterPlayerVideoFitWidgetState
     if (!mounted) {
       return;
     }
-    if (controller?.value.initialized != _initialized) {
+    final isInitialized = controller?.value.initialized ?? false;
+    if (isInitialized != _initialized) {
       setState(() {
-        _initialized = controller?.value.initialized ?? false;
+        _initialized = isInitialized;
       });
     } else {
       setState(() {});

--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -319,9 +319,7 @@ class _BetterPlayerVideoFitWidgetState
     switch (event) {
       case BetterPlayerControllerEvent.play:
         if (!_started) {
-          setState(() {
-            _updateStartedFlag();
-          });
+          setState(_updateStartedFlag);
         }
       case BetterPlayerControllerEvent.setupDataSource:
         setState(() {

--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -33,12 +33,14 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
   bool _initialized = false;
 
   StreamSubscription? _controllerEventSubscription;
+  VideoPlayerController? _videoPlayerController;
 
   @override
   void initState() {
     playerVisibilityStreamController.add(true);
     _controllerEventSubscription = widget.controller!.controllerEventStream
         .listen(_onControllerChanged);
+    _setupVideoPlayerControllerListener();
     super.initState();
   }
 
@@ -48,14 +50,30 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
       _controllerEventSubscription?.cancel();
       _controllerEventSubscription = widget.controller!.controllerEventStream
           .listen(_onControllerChanged);
+      _setupVideoPlayerControllerListener();
     }
     super.didUpdateWidget(oldWidget);
+  }
+
+  void _setupVideoPlayerControllerListener() {
+    if (_videoPlayerController != widget.controller!.videoPlayerController) {
+      _videoPlayerController?.removeListener(_onVideoPlayerChanged);
+      _videoPlayerController = widget.controller!.videoPlayerController;
+      _videoPlayerController?.addListener(_onVideoPlayerChanged);
+    }
+  }
+
+  void _onVideoPlayerChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
   void dispose() {
     playerVisibilityStreamController.close();
     _controllerEventSubscription?.cancel();
+    _videoPlayerController?.removeListener(_onVideoPlayerChanged);
     super.dispose();
   }
 
@@ -63,6 +81,9 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
     setState(() {
       if (!_initialized) {
         _initialized = true;
+      }
+      if (event == BetterPlayerControllerEvent.setupDataSource) {
+        _setupVideoPlayerControllerListener();
       }
     });
   }
@@ -254,12 +275,9 @@ class _BetterPlayerVideoFitWidgetState
       widget.betterPlayerController.videoPlayerController;
 
   bool _initialized = false;
-
-  VoidCallback? _initializedListener;
-
   bool _started = false;
-
   StreamSubscription? _controllerEventSubscription;
+  VideoPlayerController? _videoPlayerController;
 
   @override
   void initState() {
@@ -273,40 +291,22 @@ class _BetterPlayerVideoFitWidgetState
       _started = widget.betterPlayerController.hasCurrentDataSourceStarted;
     }
 
-    _initialize();
+    _initialized = controller?.value.initialized ?? false;
+    _setupControllerEventSubscription();
+    _setupVideoPlayerControllerListener();
   }
 
   @override
   void didUpdateWidget(_BetterPlayerVideoFitWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.betterPlayerController.videoPlayerController != controller) {
-      if (_initializedListener != null) {
-        oldWidget.betterPlayerController.videoPlayerController!.removeListener(
-          _initializedListener!,
-        );
-      }
-      _initialized = false;
-      _initialize();
+    if (oldWidget.betterPlayerController != widget.betterPlayerController) {
+      _setupControllerEventSubscription();
     }
+    _setupVideoPlayerControllerListener();
   }
 
-  void _initialize() {
-    if (controller?.value.initialized == false) {
-      _initializedListener = () {
-        if (!mounted) {
-          return;
-        }
-
-        if (_initialized != controller!.value.initialized) {
-          _initialized = controller!.value.initialized;
-          setState(() {});
-        }
-      };
-      controller!.addListener(_initializedListener!);
-    } else {
-      _initialized = true;
-    }
-
+  void _setupControllerEventSubscription() {
+    _controllerEventSubscription?.cancel();
     _controllerEventSubscription = widget
         .betterPlayerController
         .controllerEventStream
@@ -322,9 +322,32 @@ class _BetterPlayerVideoFitWidgetState
           if (event == BetterPlayerControllerEvent.setupDataSource) {
             setState(() {
               _started = false;
+              _initialized = false;
+              _setupVideoPlayerControllerListener();
             });
           }
         });
+  }
+
+  void _setupVideoPlayerControllerListener() {
+    if (_videoPlayerController != controller) {
+      _videoPlayerController?.removeListener(_onVideoPlayerChanged);
+      _videoPlayerController = controller;
+      _videoPlayerController?.addListener(_onVideoPlayerChanged);
+    }
+  }
+
+  void _onVideoPlayerChanged() {
+    if (!mounted) {
+      return;
+    }
+    if (controller?.value.initialized != _initialized) {
+      setState(() {
+        _initialized = controller?.value.initialized ?? false;
+      });
+    } else {
+      setState(() {});
+    }
   }
 
   @override
@@ -353,11 +376,7 @@ class _BetterPlayerVideoFitWidgetState
 
   @override
   void dispose() {
-    if (_initializedListener != null) {
-      widget.betterPlayerController.videoPlayerController!.removeListener(
-        _initializedListener!,
-      );
-    }
+    _videoPlayerController?.removeListener(_onVideoPlayerChanged);
     _controllerEventSubscription?.cancel();
     super.dispose();
   }

--- a/test/core/better_player_with_controls_test.dart
+++ b/test/core/better_player_with_controls_test.dart
@@ -74,5 +74,133 @@ void main() {
 
       expect(find.byKey(const Key('placeholder')), findsOneWidget);
     });
+
+    testWidgets('Updates aspect ratio when video size changes', (
+      WidgetTester tester,
+    ) async {
+      final mockVideoPlayerController =
+          BetterPlayerTestUtils.setupMockVideoPlayerControler();
+      final controller = BetterPlayerMockController(
+        const BetterPlayerConfiguration(),
+      );
+      controller.videoPlayerController = mockVideoPlayerController;
+
+      await controller.setupDataSource(
+        BetterPlayerDataSource.network('url'),
+      );
+
+      // Initial size (default mock might have a certain size or null)
+      mockVideoPlayerController.value = mockVideoPlayerController.value
+          .copyWith(
+            size: const Size(1280, 720),
+            duration: const Duration(seconds: 1),
+          );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BetterPlayerControllerProvider(
+            controller: controller,
+            child: BetterPlayerWithControls(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Verify initial AspectRatio
+      final initialAspectRatio = tester
+          .widget<AspectRatio>(find.byType(AspectRatio))
+          .aspectRatio;
+      expect(initialAspectRatio, 1280 / 720);
+
+      // Change video size
+      mockVideoPlayerController.value = mockVideoPlayerController.value
+          .copyWith(size: const Size(1920, 1080));
+      mockVideoPlayerController.notifyListeners();
+
+      await tester.pump();
+
+      // Verify updated AspectRatio
+      final updatedAspectRatio = tester
+          .widget<AspectRatio>(find.byType(AspectRatio))
+          .aspectRatio;
+      expect(updatedAspectRatio, 1920 / 1080);
+
+      // Change video size to something different
+      mockVideoPlayerController.value = mockVideoPlayerController.value
+          .copyWith(size: const Size(720, 1280));
+      mockVideoPlayerController.notifyListeners();
+
+      await tester.pump();
+
+      final portraitAspectRatio = tester
+          .widget<AspectRatio>(find.byType(AspectRatio))
+          .aspectRatio;
+      expect(portraitAspectRatio, 720 / 1280);
+    });
+
+    testWidgets('Updates video fit widget when video size changes', (
+      WidgetTester tester,
+    ) async {
+      final mockVideoPlayerController =
+          BetterPlayerTestUtils.setupMockVideoPlayerControler();
+      final controller = BetterPlayerMockController(
+        const BetterPlayerConfiguration(),
+      );
+      controller.videoPlayerController = mockVideoPlayerController;
+
+      await controller.setupDataSource(
+        BetterPlayerDataSource.network('url'),
+      );
+
+      mockVideoPlayerController.value = mockVideoPlayerController.value
+          .copyWith(
+            size: const Size(1280, 720),
+            duration: const Duration(seconds: 1),
+          );
+
+      // We need to trigger play for the fit widget to show (it depends on _started)
+      controller.play();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BetterPlayerControllerProvider(
+            controller: controller,
+            child: BetterPlayerWithControls(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Verify initial SizedBox size inside FittedBox
+      var sizedBox = tester.widget<SizedBox>(
+        find.descendant(
+          of: find.byType(FittedBox),
+          matching: find.byType(SizedBox),
+        ),
+      );
+      expect(sizedBox.width, 1280);
+      expect(sizedBox.height, 720);
+
+      // Change video size
+      mockVideoPlayerController.value = mockVideoPlayerController.value
+          .copyWith(size: const Size(1920, 1080));
+      mockVideoPlayerController.notifyListeners();
+
+      await tester.pump();
+
+      // Verify updated SizedBox size
+      sizedBox = tester.widget<SizedBox>(
+        find.descendant(
+          of: find.byType(FittedBox),
+          matching: find.byType(SizedBox),
+        ),
+      );
+      expect(sizedBox.width, 1920);
+      expect(sizedBox.height, 1080);
+    });
   });
 }


### PR DESCRIPTION
• Fixed: HLS ABR video sizing issues (small video in corner) on Android TV and other platforms by making UI components reactive to resolution changes reported by the native layer.