### PR TITLE
chore: prepare 1.1.1 release and fix pub score

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ Add `better_player` to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  better_player: ^1.0.1
+  better_player: ^1.1.1
 ```
 
 ## 2. Install Package

--- a/docs/migration_to_1.x.x.md
+++ b/docs/migration_to_1.x.x.md
@@ -63,24 +63,24 @@ BetterPlayerController(
 
 ```dart
 BetterPlayerController(
-  PlayerConfiguration( // [!code focus]
+  PlayerConfiguration(
     autoPlay: true,
   ),
-  betterPlayerDataSource: PlayerDataSource( // [!code focus]
-    DataSourceType.network, // [!code focus]
+  betterPlayerDataSource: PlayerDataSource(
+    DataSourceType.network,
     "https://example.com/video.mp4",
-    videoFormat: VideoFormat.hls, // [!code focus]
-    cacheConfiguration: CacheConfiguration( // [!code focus]
+    videoFormat: VideoFormat.hls,
+    cacheConfiguration: CacheConfiguration(
       useCache: true,
     ),
-    bufferingConfiguration: BufferingConfiguration( // [!code focus]
+    bufferingConfiguration: BufferingConfiguration(
       minBufferMs: 50000,
     ),
-    notificationConfiguration: NotificationConfiguration( // [!code focus]
+    notificationConfiguration: NotificationConfiguration(
       showNotification: true,
       title: "My Video",
     ),
-    drmConfiguration: DrmConfiguration( // [!code focus]
+    drmConfiguration: DrmConfiguration(
       drmType: BetterPlayerDrmType.widevine,
       licenseUrl: "https://example.com/license",
     ),
@@ -120,11 +120,11 @@ BetterPlayerControlsConfiguration(
 <td>
 
 ```dart
-PlayerControlsConfiguration( // [!code focus]
-  playerTheme: PlayerTheme.material, // [!code focus]
+PlayerControlsConfiguration(
+  playerTheme: PlayerTheme.material,
   progressBarPlayedColor: Colors.red,
   overflowMenuCustomItems: [
-    PlayerOverflowMenuItem( // [!code focus]
+    PlayerOverflowMenuItem(
       Icons.star,
       "Favorite",
       () => print("Clicked"),
@@ -163,12 +163,12 @@ final config = BetterPlayerSubtitlesConfiguration(
 <td>
 
 ```dart
-final source = PlayerSubtitlesSource( // [!code focus]
+final source = PlayerSubtitlesSource(
   type: BetterPlayerSubtitlesSourceType.network,
   urls: ["https://example.com/sub.srt"],
 );
 
-final config = PlayerSubtitlesConfiguration( // [!code focus]
+final config = PlayerSubtitlesConfiguration(
   fontSize: 20,
   fontColor: Colors.white,
 );
@@ -199,7 +199,7 @@ final playlistConfig = BetterPlayerPlaylistConfiguration(
 <td>
 
 ```dart
-final playlistConfig = PlayerPlaylistConfiguration( // [!code focus]
+final playlistConfig = PlayerPlaylistConfiguration(
   loopVideos: true,
   nextVideoDelay: Duration(seconds: 3),
 );
@@ -231,8 +231,8 @@ _controller.addEventsListener((BetterPlayerEvent event) {
 <td>
 
 ```dart
-_controller.addEventsListener((PlayerEvent event) { // [!code focus]
-  if (event.betterPlayerEventType == PlayerEventType.play) { // [!code focus]
+_controller.addEventsListener((PlayerEvent event) {
+  if (event.betterPlayerEventType == PlayerEventType.play) {
     print("Video is playing");
   }
 });

--- a/packages/better_player/CHANGELOG.md
+++ b/packages/better_player/CHANGELOG.md
@@ -1,10 +1,14 @@
+## Unreleased
+- none.
+
+## 1.1.1
+* Fixed: `fix_data.yaml` syntax error preventing downgrade analysis.
+* Updated: Removed `[!code focus]` annotations from migration docs.
+
 ## 1.1.0
 
 * Refactor: Unified model names by removing 'Better' prefix.
 * Added fix_data.yaml for automated migration.
-
-## Unreleased
-- none.
 
 ## 1.0.1
 * Add thin examples to platform packages and decoupled example app.

--- a/packages/better_player/lib/fix_data.yaml
+++ b/packages/better_player/lib/fix_data.yaml
@@ -220,7 +220,7 @@ transforms:
     date: 2026-08-27
     element:
       uris: ['package:better_player/better_player.dart']
-      class: 'BetterPlayerController'
+      inClass: 'BetterPlayerController'
       method: 'isPictureInPictureEnabled'
     changes:
       - kind: 'rename'

--- a/packages/better_player/pubspec.yaml
+++ b/packages/better_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: better_player
 resolution: workspace
 description: Advanced video player. It solves many typical use cases and it's easy to run.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/jhomlala/betterplayer/tree/master/packages/better_player
 documentation: https://jhomlala.github.io/betterplayer/
 
@@ -12,19 +12,19 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  better_player_platform_interface: ^1.0.1
-  better_player_android: ^1.0.1
-  better_player_ios: ^1.0.1
-  material_ui: ^1.0.0
-  cupertino_ui: ^1.0.0
-  cupertino_icons: ^1.0.8
+  better_player_platform_interface: ^1.1.1
+  better_player_android: ^1.1.1
+  better_player_ios: ^1.1.1
+  material_ui: ^1.1.0
+  cupertino_ui: ^1.0.1
+  cupertino_icons: ^1.0.9
   wakelock_plus: ^1.7.0
-  meta: ^1.18.0
-  flutter_widget_from_html_core: ^0.17.0
+  meta: ^1.19.0
+  flutter_widget_from_html_core: ^0.17.2
   visibility_detector: ^0.4.0+2
-  path_provider: ^2.1.5
-  collection: ^1.18.0
-  xml: ^7.0.0
+  path_provider: ^2.1.6
+  collection: ^1.19.1
+  xml: ^7.0.1
 
 dev_dependencies:
   very_good_analysis: ^10.3.0

--- a/packages/better_player_android/pubspec.yaml
+++ b/packages/better_player_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: better_player_android
 resolution: workspace
 description: Android implementation of the better_player plugin.
-version: 1.0.2
+version: 1.1.1
 homepage: https://github.com/jhomlala/betterplayer/tree/master/packages/better_player_android
 
 environment:
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  better_player_platform_interface: ^1.0.1
+  better_player_platform_interface: ^1.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/better_player_example/pubspec.yaml
+++ b/packages/better_player_example/pubspec.yaml
@@ -12,14 +12,14 @@ dependencies:
     path: ../better_player
   flutter:
     sdk: flutter
-  material_ui: ^1.0.0
-  cupertino_ui: ^1.0.0
+  material_ui: ^1.1.0
+  cupertino_ui: ^1.0.1
   flutter_localizations:
     sdk: flutter
-  path_provider: ^2.1.3
+  path_provider: ^2.1.6
   visibility_detector: ^0.4.0+2
-  collection: ^1.18.0
-  flutter_svg: ^2.0.10+1
+  collection: ^1.19.1
+  flutter_svg: ^2.3.0
 
 dev_dependencies:
   very_good_analysis: ^10.3.0

--- a/packages/better_player_ios/ios/better_player_ios.podspec
+++ b/packages/better_player_ios/ios/better_player_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'better_player_ios'
-  s.version          = '1.0.0'
+  s.version          = '1.1.1'
   s.summary          = 'iOS implementation of the better_player plugin.'
   s.description      = <<-DESC
 iOS implementation of the better_player plugin.

--- a/packages/better_player_ios/pubspec.yaml
+++ b/packages/better_player_ios/pubspec.yaml
@@ -1,7 +1,7 @@
 name: better_player_ios
 resolution: workspace
 description: iOS implementation of the better_player plugin.
-version: 1.0.2
+version: 1.1.1
 homepage: https://github.com/jhomlala/betterplayer/tree/master/packages/better_player_ios
 
 environment:
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  better_player_platform_interface: ^1.0.1
+  better_player_platform_interface: ^1.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/better_player_platform_interface/pubspec.yaml
+++ b/packages/better_player_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: better_player_platform_interface
 resolution: workspace
 description: A common platform interface for the better_player plugin.
-version: 1.0.2
+version: 1.1.1
 homepage: https://github.com/jhomlala/betterplayer/tree/master/packages/better_player_platform_interface
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  meta: ^1.18.0
+  meta: ^1.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Fix fix_data.yaml syntax for downgrade analysis
- Remove [!code focus] from docs
- Bump version to 1.1.1 in all packages and podspec
- Tighten dependency constraints