### PR TITLE
chore(rules): enforce .tmp directory for temporary triage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ node_modules/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+# Temporary files for triage
+.tmp/

--- a/docs/controls_configuration.md
+++ b/docs/controls_configuration.md
@@ -64,6 +64,8 @@ Customize the look of the seek bar:
 
 *   **`controlsHideTime`**: The duration of inactivity before controls fade out.
 *   **`customControlsBuilder`**: Provide a completely custom widget to handle the player UI. **Note**: This will only be used if `playerTheme` is set to `PlayerTheme.custom`.
+    > [!IMPORTANT]
+    > When using `customControlsBuilder` with `PlayerTheme.custom`, you are entirely responsible for managing your custom widget's state, visibility timers, animations, tap detectors, and interaction handling (such as auto-hiding or responding to `onControlsVisibilityChanged`). Unlike the built-in Material or Cupertino themes, Better Player does not automatically wrap or animate custom widgets in fade transitions or hide timers.
 *   **`showControls`**: Globally show or hide all controls.
 *   **`showControlsOnInitialize`**: Show controls immediately upon initialization.
 *   **`controlBarHeight`**: Adjust the height of the control bar.

--- a/rules/triage.md
+++ b/rules/triage.md
@@ -8,6 +8,8 @@ description: Standardized triage method for analyzing and classifying GitHub iss
 Always be pessimistic about issues reported by users if the evidence isn't clear. Most issues do not require changes to the core `better_player` packages. Changing anything in the core player is a **last resort**. Follow this triage methodology strictly and in order.
 
 > **Tooling Note**: Refer to [github.md](rules/github.md) for instructions on how to use the provided scripts to fetch issue data and comments before starting your analysis. When you need to post a reply or update an issue with your decision, use the GitHub REST API (see `rules/github.md` for the token setup).
+> **CRITICAL**: Never post a comment to GitHub without obtaining explicit user approval first.
+> **CRITICAL**: Comments should be natural and human-like. Avoid using labels like "Triage Analysis" or "Issue Triage Report" in the actual comments posted to GitHub.
 
 ---
 

--- a/rules/triage.md
+++ b/rules/triage.md
@@ -8,6 +8,7 @@ description: Standardized triage method for analyzing and classifying GitHub iss
 Always be pessimistic about issues reported by users if the evidence isn't clear. Most issues do not require changes to the core `better_player` packages. Changing anything in the core player is a **last resort**. Follow this triage methodology strictly and in order.
 
 > **Tooling Note**: Refer to [github.md](rules/github.md) for instructions on how to use the provided scripts to fetch issue data and comments before starting your analysis. When you need to post a reply or update an issue with your decision, use the GitHub REST API (see `rules/github.md` for the token setup).
+> **Temporary Files**: Any temporary files created during triage (like draft comment bodies, fetched JSON, etc.) should be written to the `.tmp/` directory in the root of the repository.
 > **CRITICAL**: Never post a comment to GitHub without obtaining explicit user approval first.
 > **CRITICAL**: Comments should be natural and human-like. Avoid using labels like "Triage Analysis" or "Issue Triage Report" in the actual comments posted to GitHub.
 


### PR DESCRIPTION
Adds .tmp/ to .gitignore and updates triage rules to enforce writing all temporary files to the .tmp/ directory.
